### PR TITLE
support javascript filter

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -73,7 +73,7 @@ class Dimension:
     def __eq__(self, other):
         return Filter(dimension=self.dimension, value=other)
 
-class Javascript:
+class JavaScript:
     def __init__(self, dim):
         self.dimension = dim
 

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -27,6 +27,11 @@ class Filter:
                                       "dimension": args["dimension"],
                                       "value": args["value"]}}
 
+        elif args["type"] == "javascript":
+            self.filter = {"filter": {"type": "javascript",
+                                      "dimension": args["dimension"],
+                                      "function": args["function"]}}                              
+
         elif args["type"] == "and":
             self.filter = {"filter": {"type": "and",
                                       "fields": args["fields"]}}
@@ -67,3 +72,10 @@ class Dimension:
 
     def __eq__(self, other):
         return Filter(dimension=self.dimension, value=other)
+
+class Javascript:
+    def __init__(self, dim):
+        self.dimension = dim
+
+    def __eq__(self, func):
+        return Filter(type='javascript', dimension=self.dimension, function=func)

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -22,6 +22,12 @@ class TestFilter:
         expected = {'type': 'selector', 'dimension': 'dim', 'value': 'val'}
         assert actual == expected
 
+    def test_javascript_filter(self):
+        actual = filters.Filter.build_filter(
+            filters.Filter(type='javascript', dimension='dim', function='function(x){return true}'))
+        expected = {'type': 'javascript', 'dimension': 'dim', 'function': 'function(x){return true}'}
+        assert actual == expected
+
     def test_and_filter(self):
         f1 = filters.Filter(dimension='dim1', value='val1')
         f2 = filters.Filter(dimension='dim2', value='val2')


### PR DESCRIPTION
Hey!

Started using pydruid for some export functionality i needed for some queries. needed to get a little more specific with JS filters and noticed there wasn't support for it. I plopped some code in and it works great locally so i decided to PR my change for review.

This would be syntax for python query:
```
filter=JavaScript('dim1') == 'function(x){return true}'
```
Let me know if this syntax could improve.

Thanks!