### PR TITLE
Add support for asynchronous client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 .idea/
 build/
 dist/
-pyDruid.egg-info/
+pydruid.egg-info/
 __pycache__
+.cache
 .eggs
+*.egg/
 \#*#
 .#*
 *~

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ README.txt
 setup.py
 pydruid
 pydruid/__init__.py
+pydruid/async_client.py
 pydruid/client.py
 pydruid/utils/__init__.py
 pydruid/utils/aggregators.py

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 #pydruid
 pydruid exposes a simple API to create, execute, and analyze [Druid](http://druid.io/) queries. pydruid can parse query results into [Pandas](http://pandas.pydata.org/) DataFrame objects for subsequent data analysis -- this offers a tight integration between [Druid](http://druid.io/), the [SciPy](http://www.scipy.org/stackspec.html) stack (for scientific computing) and [scikit-learn](http://scikit-learn.org/stable/) (for machine learning). Additionally, pydruid can export query results into TSV or JSON for further processing with your favorite tool, e.g., R, Julia, Matlab, Excel.
+It provides both synchronous and asynchronous clients.
 
 To install:
 ```python
 pip install pydruid
+# or, if you intend to use asynchronous client
+pip install pydruid[async]
+# or, if you intend to export query results into pandas
+pip install pydruid[pandas]
+# or, if you intend to do both
+pip install pydruid[async, pandas]
 ```
 Documentation: https://pythonhosted.org/pydruid/. 
 
@@ -110,3 +117,37 @@ plot(g, "tweets.png", layout=layout, vertex_size=2, bbox=(400, 400), margin=25, 
 ```
 
 ![alt text](https://github.com/metamx/pydruid/raw/master/docs/figures/twitter_graph.png "Social Network")
+
+#asynchronous client
+```pydruid.async_client.AsyncPyDruid``` implements an asynchronous client. To achieve that, it utilizes an asynchronous
+HTTP client from ```Tornado``` framework. The asynchronous client is suitable for use with async frameworks such as Tornado
+and provides much better performance at scale. It lets you serve multiple requests at the same time, without blocking on
+Druid executing your queries.
+
+##example
+```python
+from tornado import gen
+from pydruid.async_client import AsyncPyDruid
+from pydruid.utils.aggregators import longsum
+from pydruid.utils.filters import Dimension
+
+client = AsyncPyDruid(url_to_druid_broker, 'druid/v2')
+
+@gen.coroutine
+def your_asynchronous_method_serving_top10_mentions_for_day(day
+    top_mentions = yield client.topn(
+        datasource='twitterstream',
+        granularity='all',
+        intervals="%s/p1d" % (day, ),
+        aggregations={'count': doublesum('count')},
+        dimension='user_mention_name',
+        filter=(Dimension('user_lang') == 'en') & (Dimension('first_hashtag') == 'oscars') &
+               (Dimension('user_time_zone') == 'Pacific Time (US & Canada)') &
+               ~(Dimension('user_mention_name') == 'No Mention'),
+        metric='count',
+        threshold=10)
+
+    # asynchronously return results
+    # can be simply ```return top_mentions``` in python 3.x
+    raise gen.Return(top_mentions)
+```

--- a/pydruid/async_client.py
+++ b/pydruid/async_client.py
@@ -1,0 +1,158 @@
+#
+# Copyright 2016 Metamarkets Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import division
+from __future__ import absolute_import
+
+import json
+from pydruid.client import BaseDruidClient
+
+try:
+    from tornado import gen
+    from tornado.httpclient import AsyncHTTPClient, HTTPError
+except ImportError:
+    print('Warning: unable to import Tornado. The asynchronous client will not work.')
+
+
+class AsyncPyDruid(BaseDruidClient):
+    """
+    Asynchronous PyDruid client which mirrors functionality of the synchronous PyDruid, but it executes queries
+    asynchronously (using an asynchronous http client from Tornado framework).
+
+    Returns Query objects that can be used for exporting query results into TSV files or pandas.DataFrame objects
+    for subsequent analysis.
+
+    :param str url: URL of Broker node in the Druid cluster
+    :param str endpoint: Endpoint that Broker listens for queries on
+
+    Example
+
+    .. code-block:: python
+        :linenos:
+
+            >>> from pydruid.async_client import *
+
+            >>> query = AsyncPyDruid('http://localhost:8083', 'druid/v2/')
+
+            >>> top = yield query.topn(
+                    datasource='twitterstream',
+                    granularity='all',
+                    intervals='2013-10-04/pt1h',
+                    aggregations={"count": doublesum("count")},
+                    dimension='user_name',
+                    filter = Dimension('user_lang') == 'en',
+                    metric='count',
+                    threshold=2
+                )
+
+            >>> print json.dumps(top.query_dict, indent=2)
+            >>> {
+                  "metric": "count",
+                  "aggregations": [
+                    {
+                      "type": "doubleSum",
+                      "fieldName": "count",
+                      "name": "count"
+                    }
+                  ],
+                  "dimension": "user_name",
+                  "filter": {
+                    "type": "selector",
+                    "dimension": "user_lang",
+                    "value": "en"
+                  },
+                  "intervals": "2013-10-04/pt1h",
+                  "dataSource": "twitterstream",
+                  "granularity": "all",
+                  "threshold": 2,
+                  "queryType": "topN"
+                }
+
+            >>> print top.result
+            >>> [{'timestamp': '2013-10-04T00:00:00.000Z',
+                'result': [{'count': 7.0, 'user_name': 'user_1'}, {'count': 6.0, 'user_name': 'user_2'}]}]
+
+            >>> df = top.export_pandas()
+            >>> print df
+            >>>    count                 timestamp      user_name
+                0      7  2013-10-04T00:00:00.000Z         user_1
+                1      6  2013-10-04T00:00:00.000Z         user_2
+    """
+
+    def __init__(self, url, endpoint):
+        super(AsyncPyDruid, self).__init__(url, endpoint)
+
+    @gen.coroutine
+    def _post(self, query):
+        http_client = AsyncHTTPClient()
+        try:
+            headers, querystr, url = self._prepare_url_headers_and_body(query)
+            response = yield http_client.fetch(url, method='POST', headers=headers, body=querystr)
+        except HTTPError as e:
+            self.__handle_http_error(e, query)
+        else:
+            query.parse(response.body.decode("utf-8"))
+            raise gen.Return(query)
+
+    @staticmethod
+    def __handle_http_error(e, query):
+        err = None
+        if e.code == 500:
+            # has Druid returned an error?
+            try:
+                err = json.loads(e.response.body.decode("utf-8"))
+            except ValueError:
+                pass
+            else:
+                err = err.get('error', None)
+        raise IOError('{0} \n Druid Error: {1} \n Query is: {2}'.format(
+                e, err, json.dumps(query.query_dict, indent=4)))
+
+    @gen.coroutine
+    def topn(self, **kwargs):
+        query = self.query_builder.topn(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def timeseries(self, **kwargs):
+        query = self.query_builder.timeseries(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def groupby(self, **kwargs):
+        query = self.query_builder.groupby(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def segment_metadata(self, **kwargs):
+        query = self.query_builder.segment_metadata(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def time_boundary(self, **kwargs):
+        query = self.query_builder.time_boundary(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    def select(self, **kwargs):
+        query = self.query_builder.select(kwargs)
+        result = yield self._post(query)
+        raise gen.Return(result)

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -16,312 +16,41 @@
 from __future__ import division
 from __future__ import absolute_import
 
+import json
 import sys
 
-import six
 from six.moves import urllib
 
-try:
-    import pandas
-except ImportError:
-    print('Warning: unable to import Pandas. The export_pandas method will not work.')
-    pass
-
-from .utils.aggregators import *
-from .utils.postaggregator import *
-from .utils.filters import *
-from .utils.having import *
-from .utils.dimensions import build_dimension
-from .utils.query_utils import *
+from pydruid.query import QueryBuilder
 
 
-class PyDruid:
-    """
-    PyDruid contains the functions for creating and executing Druid queries, as well as
-    for exporting query results into TSV files or pandas.DataFrame objects for subsequent analysis.
-
-    :param str url: URL of Broker node in the Druid cluster
-    :param str endpoint: Endpoint that Broker listens for queries on
-
-    :ivar str result_json: JSON object representing a query result. Initial value: None
-    :ivar list result: Query result parsed into a list of dicts. Initial value: None
-    :ivar str query_type: Name of most recently run query, e.g., topN. Initial value: None
-    :ivar dict query_dict: JSON object representing the query. Initial value: None
-
-    Example
-
-    .. code-block:: python
-        :linenos:
-
-            >>> from pydruid.client import *
-
-            >>> query = PyDruid('http://localhost:8083', 'druid/v2/')
-
-            >>> top = query.topn(
-                    datasource='twitterstream',
-                    granularity='all',
-                    intervals='2013-10-04/pt1h',
-                    aggregations={"count": doublesum("count")},
-                    dimension='user_name',
-                    filter = Dimension('user_lang') == 'en',
-                    metric='count',
-                    threshold=2
-                )
-
-            >>> print json.dumps(query.query_dict, indent=2)
-            >>> {
-                  "metric": "count",
-                  "aggregations": [
-                    {
-                      "type": "doubleSum",
-                      "fieldName": "count",
-                      "name": "count"
-                    }
-                  ],
-                  "dimension": "user_name",
-                  "filter": {
-                    "type": "selector",
-                    "dimension": "user_lang",
-                    "value": "en"
-                  },
-                  "intervals": "2013-10-04/pt1h",
-                  "dataSource": "twitterstream",
-                  "granularity": "all",
-                  "threshold": 2,
-                  "queryType": "topN"
-                }
-
-            >>> print query.result
-            >>> [{'timestamp': '2013-10-04T00:00:00.000Z',
-                'result': [{'count': 7.0, 'user_name': 'user_1'}, {'count': 6.0, 'user_name': 'user_2'}]}]
-
-            >>> df = query.export_pandas()
-            >>> print df
-            >>>    count                 timestamp      user_name
-                0      7  2013-10-04T00:00:00.000Z         user_1
-                1      6  2013-10-04T00:00:00.000Z         user_2
-    """
-
+class BaseDruidClient(object):
     def __init__(self, url, endpoint):
         self.url = url
         self.endpoint = endpoint
-        self.result = None
-        self.result_json = None
-        self.query_type = None
-        self.query_dict = None
+        self.query_builder = QueryBuilder()
 
-    def __post(self, query):
-        try:
-            querystr = json.dumps(query).encode('utf-8')
-            if self.url.endswith('/'):
-                url = self.url + self.endpoint
-            else:
-                url = self.url + '/' + self.endpoint
-            headers = {'Content-Type': 'application/json'}
-            req = urllib.request.Request(url, querystr, headers)
-            res = urllib.request.urlopen(req)
-            data = res.read()
-            self.result_json = data
-            res.close()
-        except urllib.error.HTTPError:
-            _, e, _ = sys.exc_info()
-            err=None
-            if e.code==500:
-                # has Druid returned an error?
-                try:
-                    err= json.loads(e.read())
-                except ValueError:
-                    pass
-                else:
-                    err= err.get('error',None)
-
-            raise IOError('{0} \n Druid Error: {1} \n Query is: {2}'.format(
-                e, err,json.dumps(self.query_dict, indent=4)))
+    def _prepare_url_headers_and_body(self, query):
+        querystr = json.dumps(query.query_dict).encode('utf-8')
+        if self.url.endswith('/'):
+            url = self.url + self.endpoint
         else:
-            self.result = self.__parse()
-            return self.result
+            url = self.url + '/' + self.endpoint
+        headers = {'Content-Type': 'application/json'}
+        return headers, querystr, url
 
-    def __parse(self):
-        if self.result_json:
-            res = json.loads(self.result_json)
-            return res
-        else:
-            raise IOError('{Error parsing result: {0} for {1} query'.format(
-                self.result_json, self.query_type))
-
-    # --------- Export implementations ---------
-
-    def export_tsv(self, dest_path):
+    def _post(self, query):
         """
-        Export the current query result to a tsv file.
+        Fills Query object with results.
 
-        :param str dest_path: file to write query results to
-        :raise NotImplementedError:
+        :param Query query: query to execute
 
-        Example
-
-        .. code-block:: python
-            :linenos:
-
-                >>> top = query.topn(
-                        datasource='twitterstream',
-                        granularity='all',
-                        intervals='2013-10-04/pt1h',
-                        aggregations={"count": doublesum("count")},
-                        dimension='user_name',
-                        filter = Dimension('user_lang') == 'en',
-                        metric='count',
-                        threshold=2
-                    )
-
-                >>> query.export_tsv('top.tsv')
-                >>> !cat top.tsv
-                >>> count	user_name	timestamp
-                    7.0	user_1	2013-10-04T00:00:00.000Z
-                    6.0	user_2	2013-10-04T00:00:00.000Z
+        :return: Query filled with results
+        :rtype: Query
         """
-        if six.PY3:
-            f = open(dest_path, 'w', newline='', encoding='utf-8')
-        else:
-            f = open(dest_path, 'wb')
-        w = UnicodeWriter(f)
-
-        if self.query_type == "timeseries":
-            header = list(self.result[0]['result'].keys())
-            header.append('timestamp')
-        elif self.query_type == 'topN':
-            header = list(self.result[0]['result'][0].keys())
-            header.append('timestamp')
-        elif self.query_type == "groupBy":
-            header = list(self.result[0]['event'].keys())
-            header.append('timestamp')
-            header.append('version')
-        else:
-            raise NotImplementedError('TSV export not implemented for query type: {0}'.format(self.query_type))
-
-        w.writerow(header)
-
-        if self.result:
-            if self.query_type == "topN" or self.query_type == "timeseries":
-                for item in self.result:
-                    timestamp = item['timestamp']
-                    result = item['result']
-                    if type(result) is list:  # topN
-                        for line in result:
-                            w.writerow(list(line.values()) + [timestamp])
-                    else:  # timeseries
-                        w.writerow(list(result.values()) + [timestamp])
-            elif self.query_type == "groupBy":
-                for item in self.result:
-                    timestamp = item['timestamp']
-                    version = item['version']
-                    w.writerow(
-                        list(item['event'].values()) + [timestamp] + [version])
-
-        f.close()
-
-    def export_pandas(self):
-        """
-        Export the current query result to a Pandas DataFrame object.
-
-        :return: The DataFrame representing the query result
-        :rtype: DataFrame
-        :raise NotImplementedError:
-
-        Example
-
-        .. code-block:: python
-            :linenos:
-
-                >>> top = query.topn(
-                        datasource='twitterstream',
-                        granularity='all',
-                        intervals='2013-10-04/pt1h',
-                        aggregations={"count": doublesum("count")},
-                        dimension='user_name',
-                        filter = Dimension('user_lang') == 'en',
-                        metric='count',
-                        threshold=2
-                    )
-
-                >>> df = query.export_pandas()
-                >>> print df
-                >>>    count                 timestamp      user_name
-                    0      7  2013-10-04T00:00:00.000Z         user_1
-                    1      6  2013-10-04T00:00:00.000Z         user_2
-        """
-        if self.result:
-            if self.query_type == "timeseries":
-                nres = [list(v['result'].items()) + [('timestamp', v['timestamp'])]
-                        for v in self.result]
-                nres = [dict(v) for v in nres]
-            elif self.query_type == "topN":
-                nres = []
-                for item in self.result:
-                    timestamp = item['timestamp']
-                    results = item['result']
-                    tres = [dict(list(res.items()) + [('timestamp', timestamp)])
-                            for res in results]
-                    nres += tres
-            elif self.query_type == "groupBy":
-                nres = [list(v['event'].items()) + [('timestamp', v['timestamp'])]
-                        for v in self.result]
-                nres = [dict(v) for v in nres]
-            else:
-                raise NotImplementedError('Pandas export not implemented for query type: {0}'.format(self.query_type))
-
-            df = pandas.DataFrame(nres)
-            return df
+        raise NotImplementedError("Subclasses must implement this method")
 
     # --------- Query implementations ---------
-
-    def validate_query(self, valid_parts, args):
-        """
-        Validate the query parts so only allowed objects are sent.
-
-        Each query type can have an optional 'context' object attached which is used to set certain
-        query context settings, etc. timeout or priority. As each query can have this object, there's
-        no need for it to be sent - it might as well be added here.
-
-        :param list valid_parts: a list of valid object names
-        :param dict args: the dict of args to be sent
-        :raise ValueError: if an invalid object is given
-        """
-        valid_parts = valid_parts[:] + ['context']
-        for key, val in six.iteritems(args):
-            if key not in valid_parts:
-                raise ValueError(
-                    'Query component: {0} is not valid for query type: {1}.'
-                    .format(key, self.query_type) +
-                    'The list of valid components is: \n {0}'
-                    .format(valid_parts))
-
-    def build_query(self, args):
-        query_dict = {'queryType': self.query_type}
-
-        for key, val in six.iteritems(args):
-            if key == 'aggregations':
-                query_dict[key] = build_aggregators(val)
-            elif key == 'post_aggregations':
-                query_dict['postAggregations'] = Postaggregator.build_post_aggregators(val)
-            elif key == 'datasource':
-                query_dict['dataSource'] = val
-            elif key == 'paging_spec':
-                query_dict['pagingSpec'] = val
-            elif key == 'limit_spec':
-                query_dict['limitSpec'] = val
-            elif key == "filter":
-                query_dict[key] = Filter.build_filter(val)
-            elif key == "having":
-                query_dict[key] = Having.build_having(val)
-            elif key == 'dimension':
-                query_dict[key] = build_dimension(val)
-            elif key == 'dimensions':
-                query_dict[key] = [build_dimension(v) for v in val]
-            else:
-                query_dict[key] = val
-
-        self.query_dict = query_dict
 
     def topn(self, **kwargs):
         """
@@ -341,7 +70,7 @@ class PyDruid:
         :param int threshold: How many of the top items to return
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Optional key/value pairs:
 
@@ -354,7 +83,7 @@ class PyDruid:
         .. code-block:: python
             :linenos:
 
-                >>> top = query.topn(
+                >>> top = client.topn(
                             datasource='twitterstream',
                             granularity='all',
                             intervals='2013-06-14/pt1h',
@@ -368,15 +97,8 @@ class PyDruid:
                 >>> print top
                 >>> [{'timestamp': '2013-06-14T00:00:00.000Z', 'result': [{'count': 22.0, 'user': "cool_user"}}]}]
         """
-        self.query_type = 'topN'
-        valid_parts = [
-            'datasource', 'granularity', 'filter', 'aggregations',
-            'post_aggregations', 'intervals', 'dimension', 'threshold',
-            'metric'
-        ]
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.topn(kwargs)
+        return self._post(query)
 
     def timeseries(self, **kwargs):
         """
@@ -391,7 +113,7 @@ class PyDruid:
         :param dict aggregations: A map from aggregator name to one of the pydruid.utils.aggregators e.g., doublesum
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Optional key/value pairs:
 
@@ -404,7 +126,7 @@ class PyDruid:
         .. code-block:: python
             :linenos:
 
-                >>> counts = query.timeseries(
+                >>> counts = client.timeseries(
                         datasource=twitterstream,
                         granularity='hour',
                         intervals='2013-06-14/pt1h',
@@ -415,14 +137,8 @@ class PyDruid:
                 >>> print counts
                 >>> [{'timestamp': '2013-06-14T00:00:00.000Z', 'result': {'count': 9619.0, 'rows': 8007, 'percent': 120.13238416385663}}]
         """
-        self.query_type = 'timeseries'
-        valid_parts = [
-            'datasource', 'granularity', 'filter', 'aggregations',
-            'post_aggregations', 'intervals'
-        ]
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.timeseries(kwargs)
+        return self._post(query)
 
     def groupby(self, **kwargs):
         """
@@ -438,7 +154,7 @@ class PyDruid:
         :param list dimensions: The dimensions to group by
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Optional key/value pairs:
 
@@ -453,7 +169,7 @@ class PyDruid:
         .. code-block:: python
             :linenos:
 
-                >>> group = query.groupby(
+                >>> group = client.groupby(
                         datasource='twitterstream',
                         granularity='hour',
                         intervals='2013-10-04/pt1h',
@@ -472,16 +188,8 @@ class PyDruid:
                 >>> {'timestamp': '2013-10-04T00:00:00.000Z', 'version': 'v1', 'event': {'count': 1.0, 'user_name': 'user_1', 'reply_to_name': 'user_2'}}
                 >>> {'timestamp': '2013-10-04T00:00:00.000Z', 'version': 'v1', 'event': {'count': 1.0, 'user_name': 'user_2', 'reply_to_name': 'user_3'}}
         """
-
-        self.query_type = 'groupBy'
-        valid_parts = [
-            'datasource', 'granularity', 'filter', 'aggregations',
-            'having', 'post_aggregations', 'intervals', 'dimensions',
-            'limit_spec',
-        ]
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.groupby(kwargs)
+        return self._post(query)
 
     def segment_metadata(self, **kwargs):
         """
@@ -505,25 +213,22 @@ class PyDruid:
         :param dict context: A dict of query context options
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Example:
 
         .. code-block:: python
             :linenos:
 
-                >>> meta = query.segment_metadata(datasource='twitterstream', intervals = '2013-10-04/pt1h')
+                >>> meta = client.segment_metadata(datasource='twitterstream', intervals = '2013-10-04/pt1h')
                 >>> print meta[0].keys()
                 >>> ['intervals', 'id', 'columns', 'size']
                 >>> print meta[0]['columns']['tweet_length']
                 >>> {'errorMessage': None, 'cardinality': None, 'type': 'FLOAT', 'size': 30908008}
 
         """
-        self.query_type = 'segmentMetadata'
-        valid_parts = ['datasource', 'intervals']
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.segment_metadata(kwargs)
+        return self._post(query)
 
     def time_boundary(self, **kwargs):
         """
@@ -538,22 +243,19 @@ class PyDruid:
         :param dict context: A dict of query context options
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Example:
 
         .. code-block:: python
             :linenos:
 
-                >>> bound = query.time_boundary(datasource='twitterstream')
+                >>> bound = client.time_boundary(datasource='twitterstream')
                 >>> print bound
                 >>> [{'timestamp': '2011-09-14T15:00:00.000Z', 'result': {'minTime': '2011-09-14T15:00:00.000Z', 'maxTime': '2014-03-04T23:44:00.000Z'}}]
         """
-        self.query_type = 'timeBoundary'
-        valid_parts = ['datasource']
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.time_boundary(kwargs)
+        return self._post(query)
 
     def select(self, **kwargs):
         """
@@ -575,14 +277,14 @@ class PyDruid:
         :param dict context: A dict of query context options
 
         :return: The query result
-        :rtype: list[dict]
+        :rtype: Query
 
         Example:
 
         .. code-block:: python
             :linenos:
 
-                >>> raw_data = query.select(
+                >>> raw_data = client.select(
                         datasource=twitterstream,
                         granularity='all',
                         intervals='2013-06-14/pt1h',
@@ -592,11 +294,119 @@ class PyDruid:
                 >>> print raw_data
                 >>> [{'timestamp': '2013-06-14T00:00:00.000Z', 'result': {'pagingIdentifiers': {'twitterstream_2013-06-14T00:00:00.000Z_2013-06-15T00:00:00.000Z_2013-06-15T08:00:00.000Z_v1': 1, 'events': [{'segmentId': 'twitterstream_2013-06-14T00:00:00.000Z_2013-06-15T00:00:00.000Z_2013-06-15T08:00:00.000Z_v1', 'offset': 0, 'event': {'timestamp': '2013-06-14T00:00:00.000Z', 'dim': 'value'}}]}}]
         """
-        self.query_type = 'select'
-        valid_parts = [
-            'datasource', 'granularity', 'filter', 'dimensions', 'metrics',
-            'paging_spec', 'intervals'
-        ]
-        self.validate_query(valid_parts, kwargs)
-        self.build_query(kwargs)
-        return self.__post(self.query_dict)
+        query = self.query_builder.select(kwargs)
+        return self._post(query)
+
+    def export_tsv(self, dest_path):
+        """
+        Export the current query result to a tsv file.
+
+        .. deprecated::
+            Use Query.export_tsv() method instead.
+        """
+        if self.query_builder.last_query is None:
+            raise AttributeError("There was no query executed by this client yet. Can't export!")
+        else:
+            return self.query_builder.last_query.export_tsv(dest_path)
+
+    def export_pandas(self):
+        """
+        Export the current query result to a Pandas DataFrame object.
+
+        .. deprecated::
+            Use Query.export_pandas() method instead
+        """
+        if self.query_builder.last_query is None:
+            raise AttributeError("There was no query executed by this client yet. Can't export!")
+        else:
+            return self.query_builder.last_query.export_pandas()
+
+
+class PyDruid(BaseDruidClient):
+    """
+    PyDruid contains the functions for creating and executing Druid queries. Returns Query objects that can be used
+    for exporting query results into TSV files or pandas.DataFrame objects for subsequent analysis.
+
+    :param str url: URL of Broker node in the Druid cluster
+    :param str endpoint: Endpoint that Broker listens for queries on
+
+    Example
+
+    .. code-block:: python
+        :linenos:
+
+            >>> from pydruid.client import *
+
+            >>> query = PyDruid('http://localhost:8083', 'druid/v2/')
+
+            >>> top = query.topn(
+                    datasource='twitterstream',
+                    granularity='all',
+                    intervals='2013-10-04/pt1h',
+                    aggregations={"count": doublesum("count")},
+                    dimension='user_name',
+                    filter = Dimension('user_lang') == 'en',
+                    metric='count',
+                    threshold=2
+                )
+
+            >>> print json.dumps(top.query_dict, indent=2)
+            >>> {
+                  "metric": "count",
+                  "aggregations": [
+                    {
+                      "type": "doubleSum",
+                      "fieldName": "count",
+                      "name": "count"
+                    }
+                  ],
+                  "dimension": "user_name",
+                  "filter": {
+                    "type": "selector",
+                    "dimension": "user_lang",
+                    "value": "en"
+                  },
+                  "intervals": "2013-10-04/pt1h",
+                  "dataSource": "twitterstream",
+                  "granularity": "all",
+                  "threshold": 2,
+                  "queryType": "topN"
+                }
+
+            >>> print top.result
+            >>> [{'timestamp': '2013-10-04T00:00:00.000Z',
+                'result': [{'count': 7.0, 'user_name': 'user_1'}, {'count': 6.0, 'user_name': 'user_2'}]}]
+
+            >>> df = top.export_pandas()
+            >>> print df
+            >>>    count                 timestamp      user_name
+                0      7  2013-10-04T00:00:00.000Z         user_1
+                1      6  2013-10-04T00:00:00.000Z         user_2
+    """
+    def __init__(self, url, endpoint):
+        super(PyDruid, self).__init__(url, endpoint)
+
+    def _post(self, query):
+        try:
+            headers, querystr, url = self._prepare_url_headers_and_body(query)
+            req = urllib.request.Request(url, querystr, headers)
+            res = urllib.request.urlopen(req)
+            data = res.read().decode("utf-8")
+            res.close()
+        except urllib.error.HTTPError:
+            _, e, _ = sys.exc_info()
+            err = None
+            if e.code == 500:
+                # has Druid returned an error?
+                try:
+                    err = json.loads(e.read().decode("utf-8"))
+                except (ValueError, AttributeError, KeyError):
+                    pass
+                else:
+                    err = err.get('error', None)
+
+            raise IOError('{0} \n Druid Error: {1} \n Query is: {2}'.format(
+                    e, err, json.dumps(query.query_dict, indent=4)))
+        else:
+            query.parse(data)
+            return query

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -1,0 +1,369 @@
+#
+# Copyright 2016 Metamarkets Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import six
+import json
+import collections
+from pydruid.utils.aggregators import build_aggregators
+from pydruid.utils.filters import Filter
+from pydruid.utils.having import Having
+from pydruid.utils.dimensions import build_dimension
+from pydruid.utils.postaggregator import Postaggregator
+from pydruid.utils.query_utils import UnicodeWriter
+
+try:
+    import pandas
+except ImportError:
+    print('Warning: unable to import Pandas. The export_pandas method will not work.')
+    pass
+
+
+class Query(collections.MutableSequence):
+    """
+    Query objects are produced by PyDruid clients and can be used for exporting query results into TSV files or
+    pandas.DataFrame objects for subsequent analysis. They also hold information about the issued query.
+
+    Query acts as a wrapper over raw result list of dictionaries.
+
+    :ivar str result_json: JSON object representing a query result. Initial value: None
+    :ivar list result: Query result parsed into a list of dicts. Initial value: None
+    :ivar str query_type: Name of most recently run query, e.g., topN. Initial value: None
+    :ivar dict query_dict: JSON object representing the query. Initial value: None
+    """
+
+    def __init__(self, query_dict, query_type):
+        super(Query, self).__init__()
+        self.query_dict = query_dict
+        self.query_type = query_type
+        self.result = None
+        self.result_json = None
+
+    def parse(self, data):
+        if data:
+            self.result_json = data
+            res = json.loads(self.result_json)
+            self.result = res
+        else:
+            raise IOError('{Error parsing result: {0} for {1} query'.format(
+                    self.result_json, self.query_type))
+
+    def export_tsv(self, dest_path):
+        """
+        Export the current query result to a tsv file.
+
+        :param str dest_path: file to write query results to
+        :raise NotImplementedError:
+
+        Example
+
+        .. code-block:: python
+            :linenos:
+
+                >>> top = client.topn(
+                        datasource='twitterstream',
+                        granularity='all',
+                        intervals='2013-10-04/pt1h',
+                        aggregations={"count": doublesum("count")},
+                        dimension='user_name',
+                        filter = Dimension('user_lang') == 'en',
+                        metric='count',
+                        threshold=2
+                    )
+
+                >>> top.export_tsv('top.tsv')
+                >>> !cat top.tsv
+                >>> count	user_name	timestamp
+                    7.0	user_1	2013-10-04T00:00:00.000Z
+                    6.0	user_2	2013-10-04T00:00:00.000Z
+        """
+        if six.PY3:
+            f = open(dest_path, 'w', newline='', encoding='utf-8')
+        else:
+            f = open(dest_path, 'wb')
+        w = UnicodeWriter(f)
+
+        if self.query_type == "timeseries":
+            header = list(self.result[0]['result'].keys())
+            header.append('timestamp')
+        elif self.query_type == 'topN':
+            header = list(self.result[0]['result'][0].keys())
+            header.append('timestamp')
+        elif self.query_type == "groupBy":
+            header = list(self.result[0]['event'].keys())
+            header.append('timestamp')
+            header.append('version')
+        else:
+            raise NotImplementedError('TSV export not implemented for query type: {0}'.format(self.query_type))
+
+        w.writerow(header)
+
+        if self.result:
+            if self.query_type == "topN" or self.query_type == "timeseries":
+                for item in self.result:
+                    timestamp = item['timestamp']
+                    result = item['result']
+                    if type(result) is list:  # topN
+                        for line in result:
+                            w.writerow(list(line.values()) + [timestamp])
+                    else:  # timeseries
+                        w.writerow(list(result.values()) + [timestamp])
+            elif self.query_type == "groupBy":
+                for item in self.result:
+                    timestamp = item['timestamp']
+                    version = item['version']
+                    w.writerow(
+                        list(item['event'].values()) + [timestamp] + [version])
+
+        f.close()
+
+    def export_pandas(self):
+        """
+        Export the current query result to a Pandas DataFrame object.
+
+        :return: The DataFrame representing the query result
+        :rtype: DataFrame
+        :raise NotImplementedError:
+
+        Example
+
+        .. code-block:: python
+            :linenos:
+
+                >>> top = client.topn(
+                        datasource='twitterstream',
+                        granularity='all',
+                        intervals='2013-10-04/pt1h',
+                        aggregations={"count": doublesum("count")},
+                        dimension='user_name',
+                        filter = Dimension('user_lang') == 'en',
+                        metric='count',
+                        threshold=2
+                    )
+
+                >>> df = top.export_pandas()
+                >>> print df
+                >>>    count                 timestamp      user_name
+                    0      7  2013-10-04T00:00:00.000Z         user_1
+                    1      6  2013-10-04T00:00:00.000Z         user_2
+        """
+        if self.result:
+            if self.query_type == "timeseries":
+                nres = [list(v['result'].items()) + [('timestamp', v['timestamp'])]
+                        for v in self.result]
+                nres = [dict(v) for v in nres]
+            elif self.query_type == "topN":
+                nres = []
+                for item in self.result:
+                    timestamp = item['timestamp']
+                    results = item['result']
+                    tres = [dict(list(res.items()) + [('timestamp', timestamp)])
+                            for res in results]
+                    nres += tres
+            elif self.query_type == "groupBy":
+                nres = [list(v['event'].items()) + [('timestamp', v['timestamp'])]
+                        for v in self.result]
+                nres = [dict(v) for v in nres]
+            else:
+                raise NotImplementedError('Pandas export not implemented for query type: {0}'.format(self.query_type))
+
+            df = pandas.DataFrame(nres)
+            return df
+
+    def __str__(self):
+        return self.result
+
+    def __len__(self):
+        return len(self.result)
+
+    def __delitem__(self, index):
+        del self.result[index]
+
+    def insert(self, index, value):
+        self.result.insert(index, value)
+
+    def __setitem__(self, index, value):
+        self.result[index] = value
+
+    def __getitem__(self, index):
+        return self.result[index]
+
+
+class QueryBuilder(object):
+    def __init__(self):
+        self.last_query = None
+
+    @staticmethod
+    def validate_query(query_type, valid_parts, args):
+        """
+        Validate the query parts so only allowed objects are sent.
+
+        Each query type can have an optional 'context' object attached which is used to set certain
+        query context settings, etc. timeout or priority. As each query can have this object, there's
+        no need for it to be sent - it might as well be added here.
+
+        :param string query_type: a type of query
+        :param list valid_parts: a list of valid object names
+        :param dict args: the dict of args to be sent
+        :raise ValueError: if an invalid object is given
+        """
+        valid_parts = valid_parts[:] + ['context']
+        for key, val in six.iteritems(args):
+            if key not in valid_parts:
+                raise ValueError(
+                        'Query component: {0} is not valid for query type: {1}.'
+                        .format(key, query_type) +
+                        'The list of valid components is: \n {0}'
+                        .format(valid_parts))
+
+    def build_query(self, query_type, args):
+        """
+        Build query based on given query type and arguments.
+
+        :param string query_type: a type of query
+        :param dict args: the dict of args to be sent
+        :return: the resulting query
+        :rtype: Query
+        """
+        query_dict = {'queryType': query_type}
+
+        for key, val in six.iteritems(args):
+            if key == 'aggregations':
+                query_dict[key] = build_aggregators(val)
+            elif key == 'post_aggregations':
+                query_dict['postAggregations'] = Postaggregator.build_post_aggregators(val)
+            elif key == 'datasource':
+                query_dict['dataSource'] = val
+            elif key == 'paging_spec':
+                query_dict['pagingSpec'] = val
+            elif key == 'limit_spec':
+                query_dict['limitSpec'] = val
+            elif key == "filter":
+                query_dict[key] = Filter.build_filter(val)
+            elif key == "having":
+                query_dict[key] = Having.build_having(val)
+            elif key == 'dimension':
+                query_dict[key] = build_dimension(val)
+            elif key == 'dimensions':
+                query_dict[key] = [build_dimension(v) for v in val]
+            else:
+                query_dict[key] = val
+
+        self.last_query = Query(query_dict, query_type)
+        return self.last_query
+
+    def topn(self, args):
+        """
+        A TopN query returns a set of the values in a given dimension, sorted by a specified metric. Conceptually, a
+        topN can be thought of as an approximate GroupByQuery over a single dimension with an Ordering spec. TopNs are
+        faster and more resource efficient than GroupBy for this use case.
+
+        :param dict args: dict of arguments
+
+        :return: topn query
+        :rtype: Query
+        """
+        query_type = 'topN'
+        valid_parts = [
+            'datasource', 'granularity', 'filter', 'aggregations',
+            'post_aggregations', 'intervals', 'dimension', 'threshold',
+            'metric'
+        ]
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)
+
+    def timeseries(self, args):
+        """
+        A timeseries query returns the values of the requested metrics (in aggregate) for each timestamp.
+
+        :param dict args: dict of args
+
+        :return: timeseries query
+        :rtype: Query
+        """
+        query_type = 'timeseries'
+        valid_parts = [
+            'datasource', 'granularity', 'filter', 'aggregations',
+            'post_aggregations', 'intervals'
+        ]
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)
+
+    def groupby(self, args):
+        """
+        A group-by query groups a results set (the requested aggregate metrics) by the specified dimension(s).
+
+        :param dict args: dict of args
+
+        :return: group by query
+        :rtype: Query
+        """
+        query_type = 'groupBy'
+        valid_parts = [
+            'datasource', 'granularity', 'filter', 'aggregations',
+            'having', 'post_aggregations', 'intervals', 'dimensions',
+            'limit_spec',
+        ]
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)
+
+    def segment_metadata(self, args):
+        """
+        * Column type
+        * Estimated size in bytes
+        * Estimated size in bytes of each column
+        * Interval the segment covers
+        * Segment ID
+
+        :param dict args: dict of args
+
+        :return: segment metadata query
+        :rtype: Query
+        """
+        query_type = 'segmentMetadata'
+        valid_parts = ['datasource', 'intervals']
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)
+
+    def time_boundary(self, args):
+        """
+        A time boundary query returns the min and max timestamps present in a data source.
+
+        :param dict args: dict of args
+
+        :return: time boundary query
+        :rtype: Query
+        """
+        query_type = 'timeBoundary'
+        valid_parts = ['datasource']
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)
+
+    def select(self, args):
+        """
+        A select query returns raw Druid rows and supports pagination.
+
+        :param dict args: dict of args
+
+        :return: select query
+        :rtype: Query
+        """
+        query_type = 'select'
+        valid_parts = [
+            'datasource', 'granularity', 'filter', 'dimensions', 'metrics',
+            'paging_spec', 'intervals'
+        ]
+        self.validate_query(query_type, valid_parts, args)
+        return self.build_query(query_type, args)

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -30,7 +30,7 @@ class Filter:
         elif args["type"] == "javascript":
             self.filter = {"filter": {"type": "javascript",
                                       "dimension": args["dimension"],
-                                      "function": args["function"]}}                              
+                                      "function": args["function"]}}
 
         elif args["type"] == "and":
             self.filter = {"filter": {"type": "and",
@@ -87,6 +87,7 @@ class Dimension:
 
     def __ne__(self, other):
         return ~Filter(dimension=self.dimension, value=other)
+
 
 class JavaScript:
     def __init__(self, dim):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [build_sphinx]
 source-dir = docs/source
-build-dir  = docs/build
-all_files  = 1
+build-dir = docs/build
+all_files = 1
 
 [upload_sphinx]
 upload-dir = docs/build/html

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
+
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
@@ -20,7 +21,14 @@ class PyTest(TestCommand):
         sys.exit(status)
 
 
-install_requires = ["six >= 1.9.0"]
+install_requires = [
+    "six >= 1.9.0",
+]
+
+extras_require = {
+    "pandas": ["pandas"],
+    "async": ["tornado"]
+}
 
 # only require simplejson on python < 2.6
 if sys.version_info < (2, 6):
@@ -37,6 +45,7 @@ setup(
     description='A Python connector for Druid.',
     long_description='See https://github.com/druid-io/pydruid for more information.',
     install_requires=install_requires,
-    tests_require=['pytest'],
+    extras_require=extras_require,
+    tests_require=['pytest', 'six', 'mock'],
     cmdclass={'test': PyTest},
 )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,122 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2016 Metamarkets Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from mock import Mock
+from pydruid.utils.aggregators import doublesum
+from pydruid.utils.filters import Dimension
+
+try:
+    import tornado
+    import tornado.ioloop
+    import tornado.web
+    from tornado.testing import AsyncHTTPTestCase
+    from tornado.httpclient import HTTPError
+    from pydruid.async_client import AsyncPyDruid
+except ImportError:
+    tornado = Mock()
+    AsyncHTTPTestCase = object
+
+
+class FailureHandler(tornado.web.RequestHandler):
+    def post(self):
+        raise HTTPError(500, "Druid error", response="Druid error")
+
+
+class SuccessHandler(tornado.web.RequestHandler):
+    def post(self):
+        self.write("""
+            [ {
+  "timestamp" : "2015-12-30T14:14:49.000Z",
+  "result" : [ {
+    "dimension" : "aaaa",
+    "metric" : 100
+  } ]
+            } ]
+            """)
+
+
+class TestAsyncPyDruid(AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application([
+            (r"/druid/v2/fail_request", FailureHandler),
+            (r"/druid/v2/return_results", SuccessHandler)
+        ])
+
+    @tornado.testing.gen_test
+    def test_druid_returns_error(self):
+        # given
+        client = AsyncPyDruid("http://localhost:%s" % (self.get_http_port(), ),
+                              "druid/v2/fail_request")
+
+        # when / then
+        with pytest.raises(IOError):
+            yield client.topn(
+                    datasource="testdatasource",
+                    granularity="all",
+                    intervals="2015-12-29/pt1h",
+                    aggregations={"count": doublesum("count")},
+                    dimension="user_name",
+                    metric="count",
+                    filter=Dimension("user_lang") == "en",
+                    threshold=1,
+                    context={"timeout": 1000})
+
+    @tornado.testing.gen_test
+    def test_druid_returns_results(self):
+        # given
+        client = AsyncPyDruid("http://localhost:%s" % (self.get_http_port(), ),
+                              "druid/v2/return_results")
+
+        # when
+        top = yield client.topn(
+                datasource="testdatasource",
+                granularity="all",
+                intervals="2015-12-29/pt1h",
+                aggregations={"count": doublesum("count")},
+                dimension="user_name",
+                metric="count",
+                filter=Dimension("user_lang") == "en",
+                threshold=1,
+                context={"timeout": 1000})
+
+        # then
+        self.assertIsNotNone(top)
+        self.assertEqual(len(top.result), 1)
+        self.assertEqual(len(top.result[0]['result']), 1)
+
+    @tornado.testing.gen_test
+    def test_client_allows_to_export_last_query(self):
+        # given
+        client = AsyncPyDruid("http://localhost:%s" % (self.get_http_port(), ),
+                              "druid/v2/return_results")
+        yield client.topn(
+                datasource="testdatasource",
+                granularity="all",
+                intervals="2015-12-29/pt1h",
+                aggregations={"count": doublesum("count")},
+                dimension="user_name",
+                metric="count",
+                filter=Dimension("user_lang") == "en",
+                threshold=1,
+                context={"timeout": 1000})
+
+        # when / then
+        # assert that last_query.export_tsv method was called (it should throw an exception, given empty path)
+        with pytest.raises(TypeError):
+            client.export_tsv(None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,108 +1,98 @@
 # -*- coding: UTF-8 -*-
-
-import os
 import pytest
+from mock import patch, Mock
+from six.moves import urllib
 
-try:
-    import pandas
-    from pandas.util.testing import assert_frame_equal
-except ImportError:
-    pandas = None
-
-from six import PY3
 from pydruid.client import PyDruid
-from pydruid.utils import aggregators
-from pydruid.utils import postaggregator
-from pydruid.utils import filters
-from pydruid.utils import having
+from pydruid.utils.aggregators import doublesum
+from pydruid.utils.filters import Dimension
 
 
 def create_client():
-    return PyDruid('http://localhost:8083', 'druid/v2/')
+    return PyDruid("http://localhost:8083", "druid/v2/")
 
 
-def create_client_with_results():
-    client = create_client()
-    client.query_type = 'timeseries'
-    client.result = [
-        {'result': {'value1': 1, 'value2': '㬓'}, 'timestamp': '2015-01-01T00:00:00.000-05:00'},
-        {'result': {'value1': 2, 'value2': '㬓'}, 'timestamp': '2015-01-02T00:00:00.000-05:00'}
-    ]
-    return client
-
-
-def line_ending():
-    if PY3:
-        return os.linesep
-    return "\r\n"
-
-
-class TestClient:
-
-    def test_build_query(self):
+class TestPyDruid:
+    @patch('pydruid.client.urllib.request.urlopen')
+    def test_druid_returns_error(self, mock_urlopen):
+        # given
+        ex = urllib.error.HTTPError(None, 500, "Druid error", None, None)
+        mock_urlopen.side_effect = ex
         client = create_client()
-        assert client.query_dict is None
 
-        client.build_query({
-            'datasource': 'things',
-            'aggregations': {
-                'count': aggregators.count('thing'),
-            },
-            'post_aggregations': {
-                'avg': (postaggregator.Field('sum') /
-                        postaggregator.Field('count')),
-            },
-            'paging_spec': {
-                'pagingIdentifies': {},
-                'threshold': 1,
-            },
-            'filter': filters.Dimension('one') == 1,
-            'having': having.Aggregation('sum') > 1,
-            'new_key': 'value',
-        })
-        expected_query_dict = {
-            'queryType': None,
-            'dataSource': 'things',
-            'aggregations': [{'fieldName': 'thing', 'name': 'count', 'type': 'count'}],
-            'postAggregations': [{
-                'fields': [{
-                    'fieldName': 'sum', 'type': 'fieldAccess',
-                }, {
-                    'fieldName': 'count', 'type': 'fieldAccess',
-                }],
-                'fn': '/',
-                'name': 'avg',
-                'type': 'arithmetic',
-            }],
-            'pagingSpec': {'pagingIdentifies': {}, 'threshold': 1},
-            'filter': {'dimension': 'one', 'type': 'selector', 'value': 1},
-            'having': {'aggregation': 'sum', 'type': 'greaterThan', 'value': 1},
-            'new_key': 'value',
-        }
-        assert client.query_dict == expected_query_dict
+        # when / then
+        with pytest.raises(IOError):
+            client.topn(
+                    datasource="testdatasource",
+                    granularity="all",
+                    intervals="2015-12-29/pt1h",
+                    aggregations={"count": doublesum("count")},
+                    dimension="user_name",
+                    metric="count",
+                    filter=Dimension("user_lang") == "en",
+                    threshold=1,
+                    context={"timeout": 1000})
 
-    def test_validate_query(self):
+    @patch('pydruid.client.urllib.request.urlopen')
+    def test_druid_returns_results(self, mock_urlopen):
+        # given
+        response = Mock()
+        response.read.return_value = """
+            [ {
+  "timestamp" : "2015-12-30T14:14:49.000Z",
+  "result" : [ {
+    "dimension" : "aaaa",
+    "metric" : 100
+  } ]
+            } ]
+        """.encode("utf-8")
+        mock_urlopen.return_value = response
         client = create_client()
-        client.validate_query(['validkey'], {'validkey': 'value'})
-        pytest.raises(ValueError, client.validate_query, *[['validkey'], {'invalidkey': 'value'}])
 
-    def test_export_tsv(self, tmpdir):
-        client = create_client_with_results()
-        file_path = tmpdir.join('out.tsv')
-        client.export_tsv(str(file_path))
-        assert file_path.read() == "value2\tvalue1\ttimestamp" + line_ending() + "㬓\t1\t2015-01-01T00:00:00.000-05:00" + line_ending() + "㬓\t2\t2015-01-02T00:00:00.000-05:00" + line_ending()
+        # when
+        top = client.topn(
+                datasource="testdatasource",
+                granularity="all",
+                intervals="2015-12-29/pt1h",
+                aggregations={"count": doublesum("count")},
+                dimension="user_name",
+                metric="count",
+                filter=Dimension("user_lang") == "en",
+                threshold=1,
+                context={"timeout": 1000})
 
-    @pytest.mark.skipif(pandas is None, reason="requires pandas")
-    def test_export_pandas(self):
-        client = create_client_with_results()
-        df = client.export_pandas()
-        expected_df = pandas.DataFrame([{
-            'timestamp': '2015-01-01T00:00:00.000-05:00',
-            'value1': 1,
-            'value2': '㬓',
-        }, {
-            'timestamp': '2015-01-02T00:00:00.000-05:00',
-            'value1': 2,
-            'value2': '㬓',
-        }])
-        assert_frame_equal(df, expected_df)
+        # then
+        assert top is not None
+        assert len(top.result) == 1
+        assert len(top.result[0]['result']) == 1
+
+    @patch('pydruid.client.urllib.request.urlopen')
+    def test_client_allows_to_export_last_query(self, mock_urlopen):
+        # given
+        response = Mock()
+        response.read.return_value = """
+            [ {
+  "timestamp" : "2015-12-30T14:14:49.000Z",
+  "result" : [ {
+    "dimension" : "aaaa",
+    "metric" : 100
+  } ]
+            } ]
+        """.encode("utf-8")
+        mock_urlopen.return_value = response
+        client = create_client()
+        client.topn(
+                datasource="testdatasource",
+                granularity="all",
+                intervals="2015-12-29/pt1h",
+                aggregations={"count": doublesum("count")},
+                dimension="user_name",
+                metric="count",
+                filter=Dimension("user_lang") == "en",
+                threshold=1,
+                context={"timeout": 1000})
+
+        # when / then
+        # assert that last_query.export_tsv method was called (it should throw an exception, given empty path)
+        with pytest.raises(TypeError):
+            client.export_tsv(None)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,150 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2016 Metamarkets Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+
+from pydruid.query import QueryBuilder, Query
+import csv
+
+try:
+    import pandas
+    from pandas.util.testing import assert_frame_equal
+except ImportError:
+    pandas = None
+
+from six import PY3
+from pydruid.utils import aggregators
+from pydruid.utils import postaggregator
+from pydruid.utils import filters
+from pydruid.utils import having
+
+
+def create_query_with_results():
+    query = Query({}, 'timeseries')
+    query.result = [
+        {'result': {'value1': 1, 'value2': '㬓'}, 'timestamp': '2015-01-01T00:00:00.000-05:00'},
+        {'result': {'value1': 2, 'value2': '㬓'}, 'timestamp': '2015-01-02T00:00:00.000-05:00'}
+    ]
+    return query
+
+
+EXPECTED_RESULTS_PANDAS = [{
+            'timestamp': '2015-01-01T00:00:00.000-05:00',
+            'value1': 1,
+            'value2': '㬓',
+        }, {
+            'timestamp': '2015-01-02T00:00:00.000-05:00',
+            'value1': 2,
+            'value2': '㬓',
+        }]
+
+
+def expected_results_csv_reader():
+    # csv.DictReader does not perform promotion to int64
+    expected_results = []
+    for element in EXPECTED_RESULTS_PANDAS:
+        modified_elem = element.copy()
+        modified_elem.update({'value1': str(modified_elem['value1'])})
+        expected_results.append(modified_elem)
+    return expected_results
+
+
+class TestQueryBuilder:
+    def test_build_query(self):
+        # given
+        expected_query_dict = {
+            'queryType': None,
+            'dataSource': 'things',
+            'aggregations': [{'fieldName': 'thing', 'name': 'count', 'type': 'count'}],
+            'postAggregations': [{
+                'fields': [{
+                    'fieldName': 'sum', 'type': 'fieldAccess',
+                }, {
+                    'fieldName': 'count', 'type': 'fieldAccess',
+                }],
+                'fn': '/',
+                'name': 'avg',
+                'type': 'arithmetic',
+            }],
+            'pagingSpec': {'pagingIdentifies': {}, 'threshold': 1},
+            'filter': {'dimension': 'one', 'type': 'selector', 'value': 1},
+            'having': {'aggregation': 'sum', 'type': 'greaterThan', 'value': 1},
+            'new_key': 'value',
+        }
+
+        builder = QueryBuilder()
+
+        # when
+        query = builder.build_query(None, {
+            'datasource': 'things',
+            'aggregations': {
+                'count': aggregators.count('thing'),
+            },
+            'post_aggregations': {
+                'avg': (postaggregator.Field('sum') /
+                        postaggregator.Field('count')),
+            },
+            'paging_spec': {
+                'pagingIdentifies': {},
+                'threshold': 1,
+            },
+            'filter': filters.Dimension('one') == 1,
+            'having': having.Aggregation('sum') > 1,
+            'new_key': 'value',
+        })
+
+        # then
+        assert query.query_dict == expected_query_dict
+
+    def test_validate_query(self):
+        # given
+        builder = QueryBuilder()
+
+        # when
+        builder.validate_query(None, ['validkey'], {'validkey': 'value'})
+
+        # then
+        pytest.raises(ValueError, builder.validate_query, *[None, ['validkey'], {'invalidkey': 'value'}])
+
+
+class TestQuery:
+    def test_export_tsv(self, tmpdir):
+        query = create_query_with_results()
+        file_path = tmpdir.join('out.tsv')
+        query.export_tsv(str(file_path))
+
+        with open(str(file_path)) as tsv_file:
+            reader = csv.DictReader(tsv_file, delimiter="\t")
+            actual = [line for line in reader]
+            assert actual == expected_results_csv_reader()
+
+    @pytest.mark.skipif(pandas is None, reason="requires pandas")
+    def test_export_pandas(self):
+        query = create_query_with_results()
+        df = query.export_pandas()
+        expected_df = pandas.DataFrame(EXPECTED_RESULTS_PANDAS)
+        assert_frame_equal(df, expected_df)
+
+    def test_query_acts_as_a_wrapper_for_raw_result(self):
+        # given
+        query = create_query_with_results()
+
+        # then
+        assert len(query) == 2
+        assert isinstance(query[0], dict)
+        assert isinstance(query[1], dict)


### PR DESCRIPTION
**In a nutshell**: This pull request adds, in a **fully backward compatible** way, a new **optional**, **asynchronous client** to the library.

**Why this matters?** 
Druid can be very useful in many scenarios different than ad-hoc analysis of online data - f.e it can be successfully used to create flexible and interactive analytics dashboards or monitors. Applying asynchronous programming style is often a go-to architectural choice, when designing such systems - especially, when they are implemented in single threaded languages like python. The lack of asynchronous client can therefore be a serious problem. This pull request fixes it.

**What has been done?**  
* PyDruid client has been refactored to facilitate addition of a new client
 * extracted Query and QueryBuilder abstractions (tests migrated as well)
 * extracted common BaseDruidClient class
* AsyncPyDruid client implemented, which mirrors functionality of synchronous PyDruid, but works in an asynchronous way
    * the client uses an asynchronous http client
    * it is optional in the same fashion as support for pandas export
* Added minimal set of integration tests for both clients.
* setup.py enhanced to use pip extras. As a result, both pandas export and async support are explicitly declared as optional features (see updated readme for more info)
* All new (and old as well) classes are documented. Examples of usage added both to docs and readme.

**(accidentally ;)) Fixed issues:**
1. https://github.com/druid-io/pydruid/issues/29
2. https://github.com/druid-io/pydruid/commit/fa3c3660dadf106881bb92f4456acae5c0fab0d0 fixes the non-deterministic behavior of test_export_tsv. The issue originated from the fact that python dictionaries are unordered.

**A note on implementation of AsyncPyDruid:**
Asynchronous client uses elements of Tornado framework. This was a conscious choice based on the fact that Tornado is stable and mature, and integrates very well with python’s 3.5 native async support (async, await keywords) as well as other asynchronous frameworks. As a result one is not locked into using Tornado for the whole of his/her app. 
**See:** http://www.tornadoweb.org/en/stable/guide/coroutines.html#python-3-5-async-and-await

**A note on backward compatibility:**
As a result of refactoring, clients are reusable. This is achieved through clients’ query methods returning Query objects filled with results, rather than result dictionary. However, this change is fully backward compatible - clients still expose the same (now deprecated) interface allowing one to access details of the most recently executed query. Query objects on the other hand, act as wrappers around result dictionary, giving users the same dictionary interface they had before, enriched to include methods for exporting results and accessing query details.

**A note on python 2.x <-> 3.x compatibility:**
The changes have been tested and should work reliably both in python 2.x and 3.x

**Additional note on the authors:**
Changes introduced by this pull request have been originally developed in https://github.com/turu/pydruid by me (github.com/turu), and github.com/l-j. Since then, they were forked to our organization (github.com/Dreamlab) and they are already used in production. We both signed the CLA.

Best regards,
Piotr Turek
