### PR TITLE
Support for dimensions specs at query time

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -31,7 +31,9 @@ from .utils.aggregators import *
 from .utils.postaggregator import *
 from .utils.filters import *
 from .utils.having import *
+from .utils.dimensions import build_dimension
 from .utils.query_utils import *
+
 
 class PyDruid:
     """
@@ -312,6 +314,10 @@ class PyDruid:
                 query_dict[key] = Filter.build_filter(val)
             elif key == "having":
                 query_dict[key] = Having.build_having(val)
+            elif key == 'dimension':
+                query_dict[key] = build_dimension(val)
+            elif key == 'dimensions':
+                query_dict[key] = [build_dimension(v) for v in val]
             else:
                 query_dict[key] = val
 

--- a/pydruid/utils/dimensions.py
+++ b/pydruid/utils/dimensions.py
@@ -1,0 +1,114 @@
+def build_dimension(dim):
+    if isinstance(dim, DimensionSpec):
+        dim = dim.build()
+
+    return dim
+
+
+class DimensionSpec(object):
+
+    def __init__(self, dimension, output_name, extraction_function=None):
+        self._dimension = dimension
+        self._output_name = output_name
+        self._extraction_function = extraction_function
+
+    def build(self):
+        dimension_spec = {
+            'type': 'default',
+            'dimension': self._dimension,
+            'outputName': self._output_name
+        }
+
+        if self._extraction_function is not None:
+            dimension_spec['type'] = 'extraction'
+            dimension_spec['extractionFn'] = self._extraction_function.build()
+
+        return dimension_spec
+
+
+class ExtractionFunction(object):
+
+    extraction_type = None
+
+    def build(self):
+        return {'type': self.extraction_type}
+
+
+class BaseRegexExtraction(ExtractionFunction):
+
+    def __init__(self, expr):
+        super(BaseRegexExtraction, self).__init__()
+        self._expr = expr
+
+    def build(self):
+        extractor = super(BaseRegexExtraction, self).build()
+        extractor['expr'] = self._expr
+
+        return extractor
+
+
+class RegexExtraction(BaseRegexExtraction):
+
+    extraction_type = 'regex'
+
+
+class PartialExtraction(BaseRegexExtraction):
+
+    extraction_type = 'partial'
+
+
+class JavascriptExtraction(ExtractionFunction):
+
+    extraction_type = 'javascript'
+
+    def __init__(self, func, injective=False):
+        super(JavascriptExtraction, self).__init__()
+        self._func = func
+        self._injective = injective
+
+    def build(self):
+        extractor = super(JavascriptExtraction, self).build()
+        extractor['function'] = self._func
+        extractor['injective'] = self._injective
+
+        return extractor
+
+
+class LookupExtraction(ExtractionFunction):
+
+    extraction_type = 'lookup'
+    lookup_type = None
+
+    def __init__(self, retain_missing_values=False,
+                 replace_missing_values=None, injective=False):
+        super(LookupExtraction, self).__init__()
+        self._retain_missing_values = retain_missing_values
+        self._replace_missing_values = replace_missing_values
+        self._injective = injective
+
+    def build(self):
+        extractor = super(LookupExtraction, self).build()
+        extractor['lookup'] = self.build_lookup()
+        extractor['retainMissingValue'] = self._retain_missing_values
+        extractor['replaceMissingValueWith'] = self._replace_missing_values
+        extractor['injective'] = self._injective
+
+        return extractor
+
+    def build_lookup(self):
+        return {'type': self.lookup_type}
+
+
+class MapLookupExtraction(LookupExtraction):
+
+    lookup_type = 'map'
+
+    def __init__(self, mapping, **kwargs):
+        super(MapLookupExtraction, self).__init__(**kwargs)
+        self._mapping = mapping
+
+    def build_lookup(self):
+        lookup = super(MapLookupExtraction, self).build_lookup()
+        lookup['map'] = self._mapping
+
+        return lookup

--- a/tests/utils/test_dimensions.py
+++ b/tests/utils/test_dimensions.py
@@ -1,0 +1,176 @@
+from pydruid.utils.dimensions import RegexExtraction
+from pydruid.utils.dimensions import PartialExtraction
+from pydruid.utils.dimensions import JavascriptExtraction
+from pydruid.utils.dimensions import MapLookupExtraction
+from pydruid.utils.dimensions import DimensionSpec
+from pydruid.utils.dimensions import build_dimension
+
+
+class TestDimensionSpec(object):
+
+    def test_default(self):
+        dim_spec = DimensionSpec('dim', 'out')
+        actual = dim_spec.build()
+        expected = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
+
+        assert actual == expected
+
+    def test_extraction_functions(self):
+        js_func = 'function(x) {return x};'
+        ext_fns = [
+            (RegexExtraction(r'\w+'), {'type': 'regex', 'expr': '\\w+'}),
+            (PartialExtraction(r'\w+'), {'type': 'partial', 'expr': '\\w+'}),
+            (JavascriptExtraction(js_func), {
+                'type': 'javascript',
+                'function': js_func,
+                'injective': False
+            }),
+            (MapLookupExtraction(TestMapLookupExtraction.mapping), {
+                'type': 'lookup',
+                'lookup': {
+                    'type': 'map',
+                    'map': TestMapLookupExtraction.mapping
+                },
+                'retainMissingValue': False,
+                'replaceMissingValueWith': None,
+                'injective': False
+            })
+        ]
+
+        for ext_fn, expected_ext_fn in ext_fns:
+            dim_spec = DimensionSpec('dim', 'out', extraction_function=ext_fn)
+            actual = dim_spec.build()
+            expected = {
+                'type': 'extraction',
+                'dimension': 'dim',
+                'outputName': 'out',
+                'extractionFn': expected_ext_fn
+            }
+
+            assert actual == expected
+
+    def test_build_dimension(self):
+        assert build_dimension('raw_dim') == 'raw_dim'
+
+        dim_spec = DimensionSpec('dim', 'out')
+        assert build_dimension(dim_spec) == dim_spec.build()
+
+
+class TestRegexExtraction(object):
+
+    def test_regex(self):
+        ext_fn = RegexExtraction(r'\w+')
+        actual = ext_fn.build()
+        expected = {'type': 'regex', 'expr': '\\w+'}
+
+        assert actual == expected
+
+
+class TestPartialExtraction(object):
+
+    def test_regex(self):
+        ext_fn = PartialExtraction(r'\w+')
+        actual = ext_fn.build()
+        expected = {'type': 'partial', 'expr': '\\w+'}
+
+        assert actual == expected
+
+
+class TestJavascriptExtraction(object):
+
+    def test_js_injective(self):
+        js_func = 'function(x) {return x};'
+        ext_fn = JavascriptExtraction(js_func, injective=True)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'javascript',
+            'function': js_func,
+            'injective': True
+        }
+
+        assert actual == expected
+
+    def test_js_not_injective(self):
+        js_func = 'function(x) {return x};'
+        ext_fn = JavascriptExtraction(js_func)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'javascript',
+            'function': js_func,
+            'injective': False
+        }
+
+        assert actual == expected
+
+
+class TestMapLookupExtraction(object):
+
+    mapping = {
+        'foo1': 'bar1',
+        'foo2': 'bar2'
+    }
+
+    def test_map_default(self):
+        ext_fn = MapLookupExtraction(self.mapping)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'map',
+                'map': self.mapping
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': None,
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_retain_missing(self):
+        ext_fn = MapLookupExtraction(self.mapping, retain_missing_values=True)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'map',
+                'map': self.mapping
+            },
+            'retainMissingValue': True,
+            'replaceMissingValueWith': None,
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_replace_missing(self):
+        ext_fn = MapLookupExtraction(self.mapping,
+                                     replace_missing_values='replacer')
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'map',
+                'map': self.mapping
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': 'replacer',
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_injective(self):
+        ext_fn = MapLookupExtraction(self.mapping, injective=True)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'map',
+                'map': self.mapping
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': None,
+            'injective': True
+        }
+
+        assert actual == expected


### PR DESCRIPTION
Adds support for dimensions specs at query time for the following extraction functions:

- [regular expression](http://druid.io/docs/latest/querying/dimensionspecs.html#regular-expression-extraction-function)
- [partial](http://druid.io/docs/latest/querying/dimensionspecs.html#partial-extraction-function)
- [javascript](http://druid.io/docs/latest/querying/dimensionspecs.html#javascript-extraction-function)
- [map lookup](http://druid.io/docs/latest/querying/dimensionspecs.html#lookup-lookup-extraction-function)

With these merge is it possible to pass as dimensions both raw strings both `DimensionSpec` objects.

Example usage with regex extraction function:

    from pydruid.utils import dimensions
    ...

    group = query.groupby(
                dataSource='mydatasource',
                granularity='hour',
                intervals='2013-10-04/pt1h',
                dimensions=['year', dimensions.DimensionSpec(
                    'full_name', 'first_name', extraction_function=dimensions.RegexExtraction(r'(\w).*')],
                aggregations={'count': doublesum('count')}
    )

    