### PR TITLE
add `NamespaceLookupExtraction`

### DIFF
--- a/pydruid/utils/dimensions.py
+++ b/pydruid/utils/dimensions.py
@@ -112,3 +112,18 @@ class MapLookupExtraction(LookupExtraction):
         lookup['map'] = self._mapping
 
         return lookup
+
+
+class NamespaceLookupExtraction(LookupExtraction):
+
+    lookup_type = 'namespace'
+
+    def __init__(self, namespace, **kwargs):
+        super(NamespaceLookupExtraction, self).__init__(**kwargs)
+        self._namespace = namespace
+
+    def build_lookup(self):
+        lookup = super(NamespaceLookupExtraction, self).build_lookup()
+        lookup['namespace'] = self._namespace
+
+        return lookup

--- a/tests/utils/test_dimensions.py
+++ b/tests/utils/test_dimensions.py
@@ -2,6 +2,7 @@ from pydruid.utils.dimensions import RegexExtraction
 from pydruid.utils.dimensions import PartialExtraction
 from pydruid.utils.dimensions import JavascriptExtraction
 from pydruid.utils.dimensions import MapLookupExtraction
+from pydruid.utils.dimensions import NamespaceLookupExtraction
 from pydruid.utils.dimensions import DimensionSpec
 from pydruid.utils.dimensions import build_dimension
 
@@ -167,6 +168,74 @@ class TestMapLookupExtraction(object):
             'lookup': {
                 'type': 'map',
                 'map': self.mapping
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': None,
+            'injective': True
+        }
+
+        assert actual == expected
+
+
+class TestNamespaceLookupExtraction(object):
+
+    def test_map_default(self):
+        ext_fn = NamespaceLookupExtraction('foo_namespace')
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'namespace',
+                'namespace': 'foo_namespace'
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': None,
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_retain_missing(self):
+        ext_fn = NamespaceLookupExtraction('foo_namespace', retain_missing_values=True)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'namespace',
+                'namespace': 'foo_namespace'
+            },
+            'retainMissingValue': True,
+            'replaceMissingValueWith': None,
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_replace_missing(self):
+        ext_fn = NamespaceLookupExtraction('foo_namespace',
+                                     replace_missing_values='replacer')
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'namespace',
+                'namespace': 'foo_namespace'
+            },
+            'retainMissingValue': False,
+            'replaceMissingValueWith': 'replacer',
+            'injective': False
+        }
+
+        assert actual == expected
+
+    def test_map_injective(self):
+        ext_fn = NamespaceLookupExtraction('foo_namespace', injective=True)
+        actual = ext_fn.build()
+        expected = {
+            'type': 'lookup',
+            'lookup': {
+                'type': 'namespace',
+                'namespace': 'foo_namespace'
             },
             'retainMissingValue': False,
             'replaceMissingValueWith': None,


### PR DESCRIPTION
I copied the tests from `TestMapLookupExtraction`
but testing `retainMissingValue`, `injective` etc again is not really necessary
since they're actually a function of `LookupExtraction`.

I left it anyway because it's only 2 lookup extraction functions and not too messy.
If more get added I would extract the tests of `injective` etc to a separate class.
