### PR TITLE
bugfix nested `and`/`or` filters inside `not`

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -67,7 +67,7 @@ class Filter:
         return Filter(type="or", fields=[self, x])
 
     def __invert__(self):
-        return Filter(type="not", field=self.filter['filter'])
+        return Filter(type="not", field=self)
 
     @staticmethod
     def build_filter(filter_obj):
@@ -75,6 +75,8 @@ class Filter:
         if filter['type'] in ['and', 'or']:
             filter = filter.copy()  # make a copy so we don't overwrite `fields`
             filter['fields'] = [Filter.build_filter(f) for f in filter['fields']]
+        elif filter['type'] in ['not']:
+            filter['field'] = Filter.build_filter(filter['field'])
         return filter
 
 

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -133,6 +133,18 @@ class TestFilter:
         }
         assert actual == expected
 
+    def test_nested_not_or_filter(self):
+        f1 = filters.Filter(dimension='dim1', value='val1')
+        f2 = filters.Filter(dimension='dim2', value='val2')
+        actual = filters.Filter.build_filter(~(f1 | f2))
+        expected = {
+            'type': 'not',
+            'field': {'type': 'or',
+                      'fields': [{'type': 'selector', 'dimension': 'dim1', 'value': 'val1'},
+                                 {'type': 'selector', 'dimension': 'dim2', 'value': 'val2'}]}
+        }
+        assert actual == expected
+
     def test_invalid_filter(self):
         with pytest.raises(NotImplementedError):
             filters.Filter(type='invalid', dimension='dim', value='val')


### PR DESCRIPTION
I accidentally introduced a bug in #46 that only shows when you nest `and` or `or` filters inside a `not` filter.
This commit fixed that.