### PR TITLE
only import pandas when `export_pandas` gets called

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -24,12 +24,6 @@ from pydruid.utils.dimensions import build_dimension
 from pydruid.utils.postaggregator import Postaggregator
 from pydruid.utils.query_utils import UnicodeWriter
 
-try:
-    import pandas
-except ImportError:
-    print('Warning: unable to import Pandas. The export_pandas method will not work.')
-    pass
-
 
 class Query(collections.MutableSequence):
     """
@@ -159,6 +153,8 @@ class Query(collections.MutableSequence):
                     0      7  2013-10-04T00:00:00.000Z         user_1
                     1      6  2013-10-04T00:00:00.000Z         user_2
         """
+        import pandas
+
         if self.result:
             if self.query_type == "timeseries":
                 nres = [list(v['result'].items()) + [('timestamp', v['timestamp'])]


### PR DESCRIPTION
I guess in most production and testing environments pandas is not installed,
so every time you `import pydruid` anything you get an (annoying) warning message
printed even though you never use the `query.export_pandas` function.

This pull moves the import into the function so you only get an error when you
actually call `export_pandas`.
