### PR TITLE
don't raise exception when filter/having/dimension is None

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -250,11 +250,11 @@ class QueryBuilder(object):
                 query_dict['pagingSpec'] = val
             elif key == 'limit_spec':
                 query_dict['limitSpec'] = val
-            elif key == "filter":
+            elif key == "filter" and val is not None:
                 query_dict[key] = Filter.build_filter(val)
-            elif key == "having":
+            elif key == "having" and val is not None:
                 query_dict[key] = Having.build_having(val)
-            elif key == 'dimension':
+            elif key == 'dimension' and val is not None:
                 query_dict[key] = build_dimension(val)
             elif key == 'dimensions':
                 query_dict[key] = [build_dimension(v) for v in val]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -111,6 +111,44 @@ class TestQueryBuilder:
         # then
         assert query.query_dict == expected_query_dict
 
+    def test_build_query_none_type(self):
+        # given
+        expected_query_dict = {
+            'queryType': None,
+            'dataSource': 'things',
+            'aggregations': [{'fieldName': 'thing', 'name': 'count', 'type': 'count'}],
+            'filter': {'dimension': 'one', 'type': 'selector', 'value': 1},
+            'having': {'aggregation': 'sum', 'type': 'greaterThan', 'value': 1},
+            'dimension': 'dim1',
+        }
+
+        builder = QueryBuilder()
+
+        # when
+        builder_dict = {
+            'datasource': 'things',
+            'aggregations': {
+                'count': aggregators.count('thing'),
+            },
+            'filter': filters.Dimension('one') == 1,
+            'having': having.Aggregation('sum') > 1,
+            'dimension': 'dim1',
+        }
+        query = builder.build_query(None, builder_dict)
+
+        # then
+        assert query.query_dict == expected_query_dict
+
+        # you should be able to pass `None` to dimension/having/filter
+        for v in ['dimension', 'having', 'filter']:
+            expected_query_dict[v] = None
+            builder_dict[v] = None
+
+            query = builder.build_query(None, builder_dict)
+
+            assert query.query_dict == expected_query_dict
+
+
     def test_validate_query(self):
         # given
         builder = QueryBuilder()


### PR DESCRIPTION
for almost all keywords you can set the value to None.
But filter/having/dimension raises an Exception because it calls `.build_...`

fixes #30
