### PR TITLE
Bugfix when building `not` filter multiple times

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -81,6 +81,7 @@ class Filter:
             filter = filter.copy()  # make a copy so we don't overwrite `fields`
             filter['fields'] = [Filter.build_filter(f) for f in filter['fields']]
         elif filter['type'] in ['not']:
+            filter = filter.copy()
             filter['field'] = Filter.build_filter(filter['field'])
 
         return filter

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -125,8 +125,11 @@ class TestFilter:
         assert actual == expected
 
     def test_not_filter(self):
-        f = filters.Filter(dimension='dim', value='val')
-        actual = filters.Filter.build_filter(~f)
+        f = ~filters.Filter(dimension='dim', value='val')
+        actual = filters.Filter.build_filter(f)
+        # Call `build_filter` twice to make sure it does not
+        # change the passed filter object argument `f`.
+        actual = filters.Filter.build_filter(f)
         expected = {
             'type': 'not',
             'field': {'type': 'selector', 'dimension': 'dim', 'value': 'val'}


### PR DESCRIPTION
Make a copy of `filter` otherwise the `field` value (a :class:`Filter`)
of the `not` filter will be replaced with a `dict` and on next
call of `build_filter` with the same filter_obj variable will fail.

I didn't write an extra test but just modified the 'not filter test'
to call 2 times `Filter.build_filter`.
