### PR TITLE
Prepare for 0.3.1 release.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,9 @@ all_files = 1
 
 [upload_sphinx]
 upload-dir = docs/build/html
+
+[aliases]
+test=pytest
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,5 @@
 import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        status = pytest.main(self.pytest_args)
-        sys.exit(status)
-
 
 install_requires = [
     "six >= 1.9.0",
@@ -36,16 +16,16 @@ if sys.version_info < (2, 6):
 
 setup(
     name='pydruid',
-    version='0.3.0',
-    author='Deep Ganguli',
-    author_email='deep@metamarkets.com',
+    version='0.3.1',
+    author='Druid Developers',
+    author_email='druid-development@googlegroups.com',
     packages=['pydruid', 'pydruid.utils'],
-    url='http://pypi.python.org/pypi/pydruid/',
+    url='https://pypi.python.org/pypi/pydruid/',
     license='Apache License, Version 2.0',
     description='A Python connector for Druid.',
     long_description='See https://github.com/druid-io/pydruid for more information.',
     install_requires=install_requires,
     extras_require=extras_require,
+    setup_requires=['pytest-runner'],
     tests_require=['pytest', 'six', 'mock'],
-    cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
- Change author to Druid Developers
- Run tests through pytest-runner, works on both Python 2 and 3
- pydruid uses "six" for 2/3 compatibility, so add a flag to create universal wheels.