### PR TITLE
Filters extraction function

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -24,61 +24,63 @@ from .dimensions import build_dimension
 class Filter:
 
     # filter types supporting extraction function
-    _FILTERS_WITH_EXTR_FN_ = ('selector', 'regex', 'javascript', 'in', 'bound')
+    _FILTERS_WITH_EXTR_FN = ('selector', 'regex', 'javascript', 'in', 'bound',
+                             'extraction')
 
     def __init__(self, extraction_function=None, **args):
 
-        if 'type' not in args:
-            self.filter = {"filter": {"type": "selector",
-                                      "dimension": args["dimension"],
-                                      "value": args["value"]}}
-        elif args["type"] == "javascript":
-            self.filter = {"filter": {"type": "javascript",
-                                      "dimension": args["dimension"],
-                                      "function": args["function"]}}
-        elif args["type"] == "and":
-            self.filter = {"filter": {"type": "and",
-                                      "fields": args["fields"]}}
-        elif args["type"] == "or":
-            self.filter = {"filter": {"type": "or",
-                                      "fields": args["fields"]}}
-        elif args["type"] == "not":
-            self.filter = {"filter": {"type": "not",
-                                      "field": args["field"]}}
-        elif args["type"] == "in":
-            self.filter = {"filter": {"type": "in",
-                                      "dimension": args["dimension"],
-                                      "values": args["values"]}}
-        elif args["type"] == "regex":
-            self.filter = {"filter": {"type": "regex",
-                                      "dimension": args["dimension"],
-                                      "pattern": args["pattern"]}}
-        elif args["type"] == "bound":
-            self.filter = {"filter": {"type": "bound",
-                                      "dimension": args["dimension"],
-                                      "lower": args["lower"],
-                                      "lowerStrict": args["lowerStrict"],
-                                      "upper": args["upper"],
-                                      "upperStrict": args["upperStrict"],
-                                      "alphaNumeric": args["alphaNumeric"]}}
-        elif args["type"] == "columnComparison":
-            self.filter = {"filter": {"type": "columnComparison",
-                                      "dimensions": args["dimensions"]}}
-        elif args["type"] == "interval":
-            self.filter = {"filter": {"type": "interval",
-                                      "dimension": args["dimension"],
-                                      "intervals": args["intervals"]}}
-        else:
-            raise NotImplementedError(
-                'Filter type: {0} does not exist'.format(args['type']))
+        type_ = args.get('type', 'selector')
 
         if extraction_function is not None:
-            type_ = self.filter['filter']['type']
-            if type_ not in self._FILTERS_WITH_EXTR_FN_:
+            if type_ not in self._FILTERS_WITH_EXTR_FN:
                 raise ValueError('Filter of type {0} doesn\'t support '
                                  'extraction function'.format(type_))
+        elif type_ == 'extraction':
+            raise ValueError('Filter of type extraction requires extraction '
+                             'function')
+
         self.extraction_function = extraction_function
 
+        self.filter = {"filter": {"type": type_}}
+
+        if type_ == "selector":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "value": args["value"]})
+        elif type_ == "javascript":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "function": args["function"]})
+        elif type_ == "and":
+            self.filter["filter"].update({"fields": args['fields']})
+        elif type_ == "or":
+            self.filter["filter"].update({"fields": args["fields"]})
+        elif type_ == "not":
+            self.filter["filter"].update({"field": args["field"]})
+        elif type_ == "in":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "values": args["values"]})
+        elif type_ == "regex":
+            self.filter['filter'].update({"dimension": args["dimension"],
+                                          "pattern": args["pattern"]})
+        elif type_ == "bound":
+            self.filter["filter"].update({
+                "dimension": args["dimension"],
+                "lower": args["lower"],
+                "lowerStrict": args["lowerStrict"],
+                "upper": args["upper"],
+                "upperStrict": args["upperStrict"],
+                "alphaNumeric": args["alphaNumeric"]
+            })
+        elif type_ == "columnComparison":
+            self.filter['filter'].update({'dimensions': args['dimensions']})
+        elif type_ == "interval":
+            self.filter['filter'].update({'dimension': args['dimension'],
+                                          'intervals': args['intervals']})
+        elif type_ == "extraction":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "value": args["value"]})
+        else:
+            raise NotImplementedError(
+                'Filter type: {0} does not exist'.format(type_))
 
     def show(self):
         print(json.dumps(self.filter, indent=4))

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -25,7 +25,7 @@ class Filter:
 
     # filter types supporting extraction function
     _FILTERS_WITH_EXTR_FN = ('selector', 'regex', 'javascript', 'in', 'bound',
-                             'extraction')
+                             'interval', 'extraction')
 
     def __init__(self, extraction_function=None, **args):
 
@@ -176,10 +176,12 @@ class Interval(Filter):
 
     :ivar str dimension: Dimension to filter on.
     :ivar list intervals: List of ISO-8601 intervals of data to filter out.
+    :ivar ExtractionFunction extraction_function: extraction function to use,
+                                                  if not None
     """
-    def __init__(self, dimension, intervals):
+    def __init__(self, dimension, intervals, extraction_function=None):
 
         Filter.__init__(
             self,
             type='interval', dimension=dimension,
-            intervals=intervals)
+            intervals=intervals, extraction_function=extraction_function)

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -155,16 +155,18 @@ class Bound(Filter):
     :ivar bool lowerStrict: Strict lower inclusion. Initial value: False
     :ivar bool upperStrict: Strict upper inclusion. Initial value: False
     :ivar bool alphaNumeric: Numeric comparison. Initial value: False
+    :ivar ExtractionFunction extraction_function: extraction function to use,
+                                                  if not None
     """
     def __init__(
             self, dimension, lower, upper, lowerStrict=False,
-            upperStrict=False, alphaNumeric=False):
+            upperStrict=False, alphaNumeric=False, extraction_function=None):
         Filter.__init__(
             self,
             type='bound', dimension=dimension,
             lower=lower, upper=upper,
             lowerStrict=lowerStrict, upperStrict=upperStrict,
-            alphaNumeric=alphaNumeric)
+            alphaNumeric=alphaNumeric, extraction_function=extraction_function)
 
 
 class Interval(Filter):

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -59,6 +59,18 @@ class TestFilter:
         expected = {'type': 'bound', 'dimension': 'dim', 'lower': '1', 'lowerStrict': True, 'upper': '10', 'upperStrict': True, 'alphaNumeric': True}
         assert actual == expected
 
+    def test_bound_filter_with_extraction_function(self):
+        f = filters.Bound(
+            dimension='d', lower='1', upper='3', upperStrict=True,
+            extraction_function=dimensions.RegexExtraction('.*([0-9]+)'))
+        actual = filters.Filter.build_filter(f)
+        expected = {'type': 'bound', 'dimension': 'd', 'lower': '1',
+                    'lowerStrict': False, 'upper': '3', 'upperStrict': True,
+                    'alphaNumeric': False, 'extractionFn': {
+                        'type': 'regex', 'expr': '.*([0-9]+)'}}
+        assert actual == expected
+
+
     def test_interval_filter(self):
         actual = filters.Filter.build_filter(
             filters.Interval(dimension='dim', intervals=["2014-10-01T00:00:00.000Z/2014-10-07T00:00:00.000Z"]))

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -77,6 +77,20 @@ class TestFilter:
         expected = {'type': 'interval', 'dimension': 'dim', 'intervals': ["2014-10-01T00:00:00.000Z/2014-10-07T00:00:00.000Z"]}
         assert actual == expected
 
+    def test_interval_with_extraction_function(self):
+        f = filters.Interval(
+            dimension='dim', intervals=[
+                "2014-10-01T00:00:00.000Z/2014-10-07T00:00:00.000Z"],
+            extraction_function=dimensions.RegexExtraction('.*([0-9]+)')
+        )
+        actual = filters.Filter.build_filter(f)
+        expected = {
+            'type': 'interval', 'dimension': 'dim',
+            'intervals': ["2014-10-01T00:00:00.000Z/2014-10-07T00:00:00.000Z"],
+            'extractionFn': {'type': 'regex', 'expr': '.*([0-9]+)'}
+        }
+        assert actual == expected
+
     def test_and_filter(self):
         f1 = filters.Filter(dimension='dim1', value='val1')
         f2 = filters.Filter(dimension='dim2', value='val2')

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -38,6 +38,15 @@ class TestFilter:
                     'extractionFn': {'type': 'regex', 'expr': '([a-b])'}}
         assert actual == expected
 
+    def test_extraction_filter(self):
+        extraction_fn = dimensions.PartialExtraction('([a-b])')
+        f = filters.Filter(type='extraction', dimension='dim', value='v',
+                           extraction_function=extraction_fn)
+        actual = filters.Filter.build_filter(f)
+        expected = {'type': 'extraction', 'dimension': 'dim', 'value': 'v',
+                    'extractionFn': {'type': 'partial', 'expr': '([a-b])'}}
+        assert actual == expected
+
     def test_javascript_filter(self):
         actual = filters.Filter.build_filter(
             filters.Filter(type='javascript', dimension='dim', function='function(x){return true}'))

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
 
-import pytest
+from pydruid.utils import dimensions, filters
 
-from pydruid.utils import filters
-from pydruid.utils.dimensions import DimensionSpec
+import pytest
 
 
 class TestDimension:
@@ -28,6 +27,15 @@ class TestFilter:
         actual = filters.Filter.build_filter(
             filters.Filter(dimension='dim', value='val'))
         expected = {'type': 'selector', 'dimension': 'dim', 'value': 'val'}
+        assert actual == expected
+
+    def test_selector_filter_extraction_fn(self):
+        extraction_fn = dimensions.RegexExtraction('([a-b])')
+        f = filters.Filter(dimension='dim', value='v',
+                           extraction_function=extraction_fn)
+        actual = filters.Filter.build_filter(f)
+        expected = {'type': 'selector', 'dimension': 'dim', 'value': 'v',
+                    'extractionFn': {'type': 'regex', 'expr': '([a-b])'}}
         assert actual == expected
 
     def test_javascript_filter(self):
@@ -190,7 +198,7 @@ class TestFilter:
         actual = filters.Filter.build_filter(
             filters.Filter(type='columnComparison', dimensions=[
                 'dim1',
-                DimensionSpec('dim2', 'dim2')
+                dimensions.DimensionSpec('dim2', 'dim2')
             ]))
         expected = {'type': 'columnComparison', 'dimensions': [
                 'dim1',


### PR DESCRIPTION
This adds support for filters of type `extraction`, using an extraction function.

Extraction functions are also supported with filters of compatible type (this works only with druid >= 0.9.1)