### PR TITLE
thetaSketchEstimate fix py2.*

### DIFF
--- a/pydruid/utils/postaggregator.py
+++ b/pydruid/utils/postaggregator.py
@@ -152,7 +152,7 @@ class LongLeast(Postaggregator):
                 'type': 'longLeast', 'name': name, 'fields': [f.post_aggregator for f in fields]}
 
 
-class ThetaSketchOp:
+class ThetaSketchOp(object):
     def __init__(self, fn, fields, name):
         self.post_aggregator = {'type': 'thetaSketchSetOp',
                                 'name': name,


### PR DESCRIPTION
* Update ThetaSketchOp to be a "new-style" class in Python2.*.

* ThetaSketchEstimate checks the type of the incoming fields. The type
  will always be instance because in Python2 TheaSketchOp is an
  "old-style" class.

Resolves #99 