### PR TITLE
Add a way to add context to queries.

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -262,6 +262,8 @@ class QueryBuilder(object):
                 query_dict[key] = build_aggregators(val)
             elif key == 'post_aggregations':
                 query_dict['postAggregations'] = Postaggregator.build_post_aggregators(val)
+            elif key == 'context':
+                query_dict['context'] = val
             elif key == 'datasource':
                 query_dict['dataSource'] = self.parse_datasource(val, query_type)
             elif key == 'paging_spec':


### PR DESCRIPTION
We use the context data fields like "queryId" to filter queries at druid backend. I thought it'll be beneficial for others as well. Context is already a valid param but isn't used anywhere. 