### PR TITLE
[py2] fix str check in parse_datasource

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -214,11 +214,11 @@ class QueryBuilder(object):
         :raise ValueError: if input is not string or list of strings
         """
         if not (
-                    isinstance(datasource, str) or
-                    (isinstance(datasource, list) and all([isinstance(x, str) for x in datasource]))
+                    isinstance(datasource, six.string_types) or
+                    (isinstance(datasource, list) and all([isinstance(x, six.string_types) for x in datasource]))
                 ):
             raise ValueError('Datasource definition not valid. Must be string or list of strings')
-        if isinstance(datasource, str):
+        if isinstance(datasource, six.string_types):
             return datasource
         else:
             return {'type': 'union', 'dataSources': datasource}


### PR DESCRIPTION
Checking for `str` type in python2.* doesn't work because in many cases
string will be unicode.

This PR makes use of the `six` lib to make the call py2/3 compatible