### PR TITLE
Added support for "expression" in aggregators

### DIFF
--- a/pydruid/utils/aggregators.py
+++ b/pydruid/utils/aggregators.py
@@ -67,6 +67,8 @@ def count(raw_metric):
 def hyperunique(raw_metric):
     return {"type": "hyperUnique", "fieldName": raw_metric}
 
+def expression(raw_metric, aggregation):
+    return {"expression": "\""+raw_metric+"\"", "type":aggregation}
 
 def cardinality(raw_column, by_row=False):
     if type(raw_column) is not list:


### PR DESCRIPTION
If numeric data is stored as String, one will not be able to perform aggregations on it. This fix provides a solution to this problem.
Example: 
aggregations={"total": expression("amount", "doubleSum")},
will perform doubleSum on the "amount" field and return the result as "total"