### PR TITLE
[Easy] Check if connection is closed before execute

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -132,6 +132,7 @@ class Connection(object):
 
         return cursor
 
+    @check_closed
     def execute(self, operation, parameters=None):
         cursor = self.cursor()
         return cursor.execute(operation, parameters)


### PR DESCRIPTION
The `execute` method in the connection was missing the `check_closed` decorator.