### PR TITLE
Get b64encoding correct for python 2 & 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 pydruid.egg-info/
 __pycache__
+.pytest_cache/
 .cache
 .eggs
 *.egg/

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -24,6 +24,7 @@ from six.moves import urllib
 from pydruid.query import QueryBuilder
 from base64 import b64encode
 
+
 class BaseDruidClient(object):
     def __init__(self, url, endpoint):
         self.url = url

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -45,10 +45,9 @@ class BaseDruidClient(object):
             url = self.url + '/' + self.endpoint
         headers = {'Content-Type': 'application/json'}
         if (self.username is not None) and (self.password is not None):
-            username_password = \
-                b64encode(bytes('{}:{}'.format(self.username, self.password),
-                                encoding='utf-8'))
-            headers['Authorization'] = 'Basic {}'.format(username_password)
+            authstring = '{}:{}'.format(self.username, self.password)
+            b64string = b64encode(authstring.encode()).decode()
+            headers['Authorization'] = 'Basic {}'.format(b64string)
 
         return headers, querystr, url
 

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -31,7 +31,7 @@ class BaseDruidClient(object):
         self.query_builder = QueryBuilder()
         self.username = None
         self.password = None
-        
+
     def set_basic_auth_credentials(self, username, password):
         self.username = username
         self.password = password
@@ -45,9 +45,10 @@ class BaseDruidClient(object):
         headers = {'Content-Type': 'application/json'}
         if (self.username is not None) and (self.password is not None):
             username_password = \
-                b64encode(bytes('{}:{}'.format(self.username, self.password)))
+                b64encode(bytes('{}:{}'.format(self.username, self.password),
+                                encoding='utf-8'))
             headers['Authorization'] = 'Basic {}'.format(username_password)
-            
+
         return headers, querystr, url
 
     def _post(self, query):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -108,4 +108,4 @@ class TestPyDruid:
         query = create_blank_query()
         client.set_basic_auth_credentials('myUsername', 'myPassword')
         headers, _, _ = client._prepare_url_headers_and_body(query)
-        assert headers['Authorization'] == "Basic b'bXlVc2VybmFtZTpteVBhc3N3b3Jk'"
+        assert headers['Authorization'] == "Basic bXlVc2VybmFtZTpteVBhc3N3b3Jk"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,12 +4,17 @@ from mock import patch, Mock
 from six.moves import urllib
 
 from pydruid.client import PyDruid
+from pydruid.query import Query
 from pydruid.utils.aggregators import doublesum
 from pydruid.utils.filters import Dimension
 
 
 def create_client():
     return PyDruid("http://localhost:8083", "druid/v2/")
+
+
+def create_blank_query():
+    return Query({}, 'none')
 
 
 class TestPyDruid:
@@ -96,3 +101,11 @@ class TestPyDruid:
         # assert that last_query.export_tsv method was called (it should throw an exception, given empty path)
         with pytest.raises(TypeError):
             client.export_tsv(None)
+
+    @patch('pydruid.client.urllib.request.urlopen')
+    def test_client_auth_creds(self, mock_urlopen):
+        client = create_client()
+        query = create_blank_query()
+        client.set_basic_auth_credentials('myUsername', 'myPassword')
+        headers, _, _ = client._prepare_url_headers_and_body(query)
+        assert headers['Authorization'] == "Basic b'bXlVc2VybmFtZTpteVBhc3N3b3Jk'"


### PR DESCRIPTION
I was trying 'master' branch and kept getting the following

```
File "/usr/local/lib/python3.6/site-packages/pydruid/client.py", line 48, in _prepare_url_headers_and_body
    b64encode(bytes('{}:{}'.format(self.username, self.password)))
TypeError: string argument without an encoding
```

Python3 uses either b'mystring' or bytes('mystring', encoding='myencoding'), so I put together a small patch.  Hoping it still works with Python2, but not tested.