### PR TITLE
Surface HTML errors

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -507,7 +507,9 @@ class PyDruid(BaseDruidClient):
                     pass
 
             raise IOError('{0} \n Druid Error: {1} \n Query is: {2}'.format(
-                    e, err, json.dumps(query.query_dict, indent=4)))
+                    e,
+                    err,
+                    json.dumps(query.query_dict, indent=4, sort_keys=True)))
         else:
             query.parse(data)
             return query

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -488,10 +488,9 @@ class PyDruid(BaseDruidClient):
             data = res.read().decode("utf-8")
             res.close()
         except urllib.error.HTTPError as e:
-            err = None
+            err = e.reason
             if e.code == 500:
                 # has Druid returned an error?
-                err = e.read().decode("utf-8")
                 try:
                     err = json.loads(err)
                 except json.decoder.JSONDecodeError:

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -24,12 +24,6 @@ from six.moves import urllib
 from pydruid.query import QueryBuilder
 from base64 import b64encode
 
-try:
-    # available only in Python >= 3.5
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
-
 
 # extract error from the <PRE> tag inside the HTML response
 HTML_ERROR = re.compile('<pre>\s*(.*?)\s*</pre>', re.IGNORECASE)
@@ -500,7 +494,7 @@ class PyDruid(BaseDruidClient):
                 # has Druid returned an error?
                 try:
                     err = json.loads(err)
-                except JSONDecodeError:
+                except ValueError:
                     if HTML_ERROR.search(err):
                         err = HTML_ERROR.search(err).group(1)
                 except (ValueError, AttributeError, KeyError):

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -24,6 +24,13 @@ from six.moves import urllib
 from pydruid.query import QueryBuilder
 from base64 import b64encode
 
+try:
+    # available only in Python >= 3.5
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
+
 # extract error from the <PRE> tag inside the HTML response
 HTML_ERROR = re.compile('<pre>\s*(.*?)\s*</pre>', re.IGNORECASE)
 
@@ -493,7 +500,7 @@ class PyDruid(BaseDruidClient):
                 # has Druid returned an error?
                 try:
                     err = json.loads(err)
-                except json.decoder.JSONDecodeError:
+                except JSONDecodeError:
                     if HTML_ERROR.search(err):
                         err = HTML_ERROR.search(err).group(1)
                 except (ValueError, AttributeError, KeyError):

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -507,9 +507,11 @@ class PyDruid(BaseDruidClient):
                     pass
 
             raise IOError('{0} \n Druid Error: {1} \n Query is: {2}'.format(
-                    e,
-                    err,
-                    json.dumps(query.query_dict, indent=4, sort_keys=True)))
+                    e, err, json.dumps(
+                        query.query_dict,
+                        indent=4,
+                        sort_keys=True,
+                        separators=(',', ': '))))
         else:
             query.parse(data)
             return query

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,6 @@
 # -*- coding: UTF-8 -*-
+import textwrap
+
 import pytest
 from mock import patch, Mock
 from six.moves import urllib
@@ -41,18 +43,20 @@ class TestPyDruid:
     @patch('pydruid.client.urllib.request.urlopen')
     def test_druid_returns_html_error(self, mock_urlopen):
         # given
-        message = """<html>
-<head>
-<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
-<title>Error 500 </title>
-</head>
-<body>
-<h2>HTTP ERROR: 500</h2>
-<p>Problem accessing /druid/v2/. Reason:
-<pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
-<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
-</body>
-</html>"""
+        message = textwrap.dedent("""
+            <html>
+            <head>
+            <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
+            <title>Error 500 </title>
+            </head>
+            <body>
+            <h2>HTTP ERROR: 500</h2>
+            <p>Problem accessing /druid/v2/. Reason:
+            <pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
+            <hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
+            </body>
+            </html>
+        """).strip()
         ex = urllib.error.HTTPError(None, 500, message, None, None)
         mock_urlopen.side_effect = ex
         client = create_client()
@@ -70,43 +74,45 @@ class TestPyDruid:
                     threshold=1,
                     context={"timeout": 1000})
 
-        assert str(e.value) == """HTTP Error 500: <html>
-<head>
-<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
-<title>Error 500 </title>
-</head>
-<body>
-<h2>HTTP ERROR: 500</h2>
-<p>Problem accessing /druid/v2/. Reason:
-<pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
-<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
-</body>
-</html> 
- Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
- Query is: {
-    "aggregations": [
-        {
-            "fieldName": "count",
-            "name": "count",
-            "type": "doubleSum"
-        }
-    ],
-    "context": {
-        "timeout": 1000
-    },
-    "dataSource": "testdatasource",
-    "dimension": "user_name",
-    "filter": {
-        "dimension": "user_lang",
-        "type": "selector",
-        "value": "en"
-    },
-    "granularity": "all",
-    "intervals": "2015-12-29/pt1h",
-    "metric": "count",
-    "queryType": "topN",
-    "threshold": 1
-}"""
+        assert str(e.value) == textwrap.dedent("""
+            HTTP Error 500: <html>
+            <head>
+            <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
+            <title>Error 500 </title>
+            </head>
+            <body>
+            <h2>HTTP ERROR: 500</h2>
+            <p>Problem accessing /druid/v2/. Reason:
+            <pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
+            <hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
+            </body>
+            </html> 
+             Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
+             Query is: {
+                "aggregations": [
+                    {
+                        "fieldName": "count",
+                        "name": "count",
+                        "type": "doubleSum"
+                    }
+                ],
+                "context": {
+                    "timeout": 1000
+                },
+                "dataSource": "testdatasource",
+                "dimension": "user_name",
+                "filter": {
+                    "dimension": "user_lang",
+                    "type": "selector",
+                    "value": "en"
+                },
+                "granularity": "all",
+                "intervals": "2015-12-29/pt1h",
+                "metric": "count",
+                "queryType": "topN",
+                "threshold": 1
+            }
+        """).strip()
 
     @patch('pydruid.client.urllib.request.urlopen')
     def test_druid_returns_results(self, mock_urlopen):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,7 +53,6 @@ class TestPyDruid:
 <hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
 </body>
 </html>"""
-        message = "Druid error"
         ex = urllib.error.HTTPError(None, 500, message, None, None)
         mock_urlopen.side_effect = ex
         client = create_client()
@@ -71,10 +70,43 @@ class TestPyDruid:
                     threshold=1,
                     context={"timeout": 1000})
 
-        assert str(e.value) == (
-            'javax.servlet.ServletException: java.lang.OutOfMemoryError: '
-            'GC overhead limit exceeded'
-        )
+        assert str(e.value) == """HTTP Error 500: <html>
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
+<title>Error 500 </title>
+</head>
+<body>
+<h2>HTTP ERROR: 500</h2>
+<p>Problem accessing /druid/v2/. Reason:
+<pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
+<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
+</body>
+</html> 
+ Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
+ Query is: {
+    "queryType": "topN",
+    "dataSource": "testdatasource",
+    "granularity": "all",
+    "intervals": "2015-12-29/pt1h",
+    "aggregations": [
+        {
+            "type": "doubleSum",
+            "fieldName": "count",
+            "name": "count"
+        }
+    ],
+    "dimension": "user_name",
+    "metric": "count",
+    "filter": {
+        "type": "selector",
+        "dimension": "user_lang",
+        "value": "en"
+    },
+    "threshold": 1,
+    "context": {
+        "timeout": 1000
+    }
+}"""
 
     @patch('pydruid.client.urllib.request.urlopen')
     def test_druid_returns_results(self, mock_urlopen):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,28 +84,28 @@ class TestPyDruid:
 </html> 
  Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
  Query is: {
-    "queryType": "topN",
-    "dataSource": "testdatasource",
-    "granularity": "all",
-    "intervals": "2015-12-29/pt1h",
     "aggregations": [
         {
-            "type": "doubleSum",
             "fieldName": "count",
-            "name": "count"
+            "name": "count",
+            "type": "doubleSum"
         }
     ],
-    "dimension": "user_name",
-    "metric": "count",
-    "filter": {
-        "type": "selector",
-        "dimension": "user_lang",
-        "value": "en"
-    },
-    "threshold": 1,
     "context": {
         "timeout": 1000
-    }
+    },
+    "dataSource": "testdatasource",
+    "dimension": "user_name",
+    "filter": {
+        "dimension": "user_lang",
+        "type": "selector",
+        "value": "en"
+    },
+    "granularity": "all",
+    "intervals": "2015-12-29/pt1h",
+    "metric": "count",
+    "queryType": "topN",
+    "threshold": 1
 }"""
 
     @patch('pydruid.client.urllib.request.urlopen')


### PR DESCRIPTION
Our Druid cluster is returning an HTML error message when OOMing:

```html
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 </title>
</head>
<body>
<h2>HTTP ERROR: 500</h2>
<p>Problem accessing /druid/v2/. Reason:
<pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
</body>
</html>
```

This message is not surfaced correctly to the client, since the client expects a JSON response from Druid. Here's how it's currently surfaced:

```
{"error": "HTTP Error 500: Server Error \n Druid Error: None \n Query is: {\n    \"queryType\": \"scan\",\n    \"dataSource\": \"driver_locations\",\n    \"dimensions\": [\n        \"location\"\n    ],\n    \"granularity\": \"all\",\n    \"intervals\": \"2011-02-13T00:00:00+00:00/2101-01-01T00:00:00+00:00\",\n    \"metrics\": [],\n    \"limit\": 50000\n}"}
```

I modified the code that checks for errors in the client so that if an HTML response is returned the error message is correctly extracted from the `<PRE></PRE>` tags. With this, the error is surfaced correctly (although somewhat verbose):

```
HTTP Error 500: <html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 </title>
</head>
<body>
<h2>HTTP ERROR: 500</h2>
<p>Problem accessing /druid/v2/. Reason:
<pre>    javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded</pre></p>
<hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.19.v20170502</a><hr/>
</body>
</html>
 Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded
 Query is: {
    "queryType": "topN",
    "dataSource": "testdatasource",
    "granularity": "all",
    "intervals": "2015-12-29/pt1h",
    "aggregations": [
        {
            "type": "doubleSum",
            "fieldName": "count",
            "name": "count"
        }
    ],
    "dimension": "user_name",
    "metric": "count",
    "filter": {
        "type": "selector",
        "dimension": "user_lang",
        "value": "en"
    },
    "threshold": 1,
    "context": {
        "timeout": 1000
    }
}
```