### PR TITLE
Implement Filtered DimensionSpecs

### DIFF
--- a/pydruid/utils/dimensions.py
+++ b/pydruid/utils/dimensions.py
@@ -38,7 +38,7 @@ class FilteredSpec(object):
     def build(self, delegate):
         dimension_spec = {
             'type': self.filter_type,
-            'delegate': delegate
+            'delegate': delegate,
         }
         return dimension_spec
 

--- a/pydruid/utils/dimensions.py
+++ b/pydruid/utils/dimensions.py
@@ -26,6 +26,55 @@ class DimensionSpec(object):
         return dimension_spec
 
 
+class FilteredSpec(object):
+
+    filter_type = None
+
+    def __init__(self, dimension_spec):
+        self._delegate = dimension_spec
+
+    def build(self):
+        dimension_spec = {
+            'type': self.filter_type,
+            'delegate': self._delegate.build()
+        }
+        return dimension_spec
+
+
+class ListFilteredSpec(FilteredSpec):
+
+    filter_type = 'listFiltered'
+
+    def __init__(self, dimension_spec, values, is_whitelist=True):
+        super(ListFilteredSpec, self).__init__(dimension_spec)
+        self._values = values
+        self._is_whitelist = is_whitelist
+
+    def build(self):
+        dimension_spec = super(ListFilteredSpec, self).build()
+        dimension_spec['values'] = self._values
+
+        if not self._is_whitelist:
+            dimension_spec['isWhitelist'] = False
+
+        return dimension_spec
+
+
+class RegexFilteredSpec(FilteredSpec):
+
+    filter_type = 'regexFiltered'
+
+    def __init__(self, dimension_spec, pattern):
+        super(RegexFilteredSpec, self).__init__(dimension_spec)
+        self._pattern = pattern
+
+    def build(self):
+        dimension_spec = super(RegexFilteredSpec, self).build()
+        dimension_spec['pattern'] = self._pattern
+
+        return dimension_spec
+
+
 class ExtractionFunction(object):
 
     extraction_type = None

--- a/tests/utils/test_dimensions.py
+++ b/tests/utils/test_dimensions.py
@@ -53,6 +53,33 @@ class TestDimensionSpec(object):
 
             assert actual == expected
 
+    def test_filter_specs(self):
+        delegate_spec = DimensionSpec('dim', 'out').build()
+        filter_specs = [
+            (ListFilteredSpec(['val1', 'val2']), {
+                'type': 'listFiltered',
+                'delegate': delegate_spec,
+                'values': ['val1', 'val2']
+            }),
+            (ListFilteredSpec(['val1', 'val2'], is_whitelist=False), {
+                'type': 'listFiltered',
+                'delegate': delegate_spec,
+                'values': ['val1', 'val2'],
+                'isWhitelist': False
+            }),
+            (RegexFilteredSpec(r'\w+'), {
+                'type': 'regexFiltered',
+                'delegate': delegate_spec,
+                'pattern': '\\w+'
+            })
+        ]
+
+        for filter_spec, expected_dim_spec in filter_specs:
+            dim_spec = DimensionSpec('dim', 'out', filter_spec=filter_spec)
+            actual = dim_spec.build()
+
+            assert actual == expected_dim_spec
+
     def test_build_dimension(self):
         assert build_dimension('raw_dim') == 'raw_dim'
 
@@ -63,9 +90,9 @@ class TestDimensionSpec(object):
 class TestListFilteredSpec(object):
 
     def test_list_filtered_spec(self):
-        dim_spec = DimensionSpec('dim', 'out')
-        list_filtered_spec = ListFilteredSpec(dim_spec, ['val1', 'val2'])
-        actual = list_filtered_spec.build()
+        dim_spec = DimensionSpec('dim', 'out').build()
+        list_filtered_spec = ListFilteredSpec(['val1', 'val2'])
+        actual = list_filtered_spec.build(dim_spec)
         expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
         expected = {
             'type': 'listFiltered',
@@ -76,10 +103,9 @@ class TestListFilteredSpec(object):
         assert actual == expected
 
     def test_list_filtered_spec_whitelist(self):
-        dim_spec = DimensionSpec('dim', 'out')
-        list_filtered_spec = ListFilteredSpec(dim_spec, ['val1', 'val2'],
-            is_whitelist=False)
-        actual = list_filtered_spec.build()
+        dim_spec = DimensionSpec('dim', 'out').build()
+        list_filtered_spec = ListFilteredSpec(['val1', 'val2'], is_whitelist=False)
+        actual = list_filtered_spec.build(dim_spec)
         expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
         expected = {
             'type': 'listFiltered',
@@ -94,9 +120,9 @@ class TestListFilteredSpec(object):
 class TestRegexFilteredSpec(object):
 
     def test_regex_filtered_spec(self):
-        dim_spec = DimensionSpec('dim', 'out')
-        regex_filtered_spec = RegexFilteredSpec(dim_spec, r'\w+')
-        actual = regex_filtered_spec.build()
+        dim_spec = DimensionSpec('dim', 'out').build()
+        regex_filtered_spec = RegexFilteredSpec(r'\w+')
+        actual = regex_filtered_spec.build(dim_spec)
         expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
         expected = {
             'type': 'regexFiltered',

--- a/tests/utils/test_dimensions.py
+++ b/tests/utils/test_dimensions.py
@@ -1,3 +1,5 @@
+from pydruid.utils.dimensions import ListFilteredSpec
+from pydruid.utils.dimensions import RegexFilteredSpec
 from pydruid.utils.dimensions import RegexExtraction
 from pydruid.utils.dimensions import PartialExtraction
 from pydruid.utils.dimensions import JavascriptExtraction
@@ -56,6 +58,53 @@ class TestDimensionSpec(object):
 
         dim_spec = DimensionSpec('dim', 'out')
         assert build_dimension(dim_spec) == dim_spec.build()
+
+
+class TestListFilteredSpec(object):
+
+    def test_list_filtered_spec(self):
+        dim_spec = DimensionSpec('dim', 'out')
+        list_filtered_spec = ListFilteredSpec(dim_spec, ['val1', 'val2'])
+        actual = list_filtered_spec.build()
+        expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
+        expected = {
+            'type': 'listFiltered',
+            'delegate': expected_dim_spec,
+            'values': ['val1', 'val2']
+        }
+
+        assert actual == expected
+
+    def test_list_filtered_spec_whitelist(self):
+        dim_spec = DimensionSpec('dim', 'out')
+        list_filtered_spec = ListFilteredSpec(dim_spec, ['val1', 'val2'],
+            is_whitelist=False)
+        actual = list_filtered_spec.build()
+        expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
+        expected = {
+            'type': 'listFiltered',
+            'delegate': expected_dim_spec,
+            'values': ['val1', 'val2'],
+            'isWhitelist': False
+        }
+
+        assert actual == expected
+
+
+class TestRegexFilteredSpec(object):
+
+    def test_regex_filtered_spec(self):
+        dim_spec = DimensionSpec('dim', 'out')
+        regex_filtered_spec = RegexFilteredSpec(dim_spec, r'\w+')
+        actual = regex_filtered_spec.build()
+        expected_dim_spec = {'type': 'default', 'dimension': 'dim', 'outputName': 'out'}
+        expected = {
+            'type': 'regexFiltered',
+            'delegate': expected_dim_spec,
+            'pattern': '\\w+'
+        }
+
+        assert actual == expected
 
 
 class TestRegexExtraction(object):

--- a/tests/utils/test_dimensions.py
+++ b/tests/utils/test_dimensions.py
@@ -59,18 +59,18 @@ class TestDimensionSpec(object):
             (ListFilteredSpec(['val1', 'val2']), {
                 'type': 'listFiltered',
                 'delegate': delegate_spec,
-                'values': ['val1', 'val2']
+                'values': ['val1', 'val2'],
             }),
             (ListFilteredSpec(['val1', 'val2'], is_whitelist=False), {
                 'type': 'listFiltered',
                 'delegate': delegate_spec,
                 'values': ['val1', 'val2'],
-                'isWhitelist': False
+                'isWhitelist': False,
             }),
             (RegexFilteredSpec(r'\w+'), {
                 'type': 'regexFiltered',
                 'delegate': delegate_spec,
-                'pattern': '\\w+'
+                'pattern': '\\w+',
             })
         ]
 
@@ -97,7 +97,7 @@ class TestListFilteredSpec(object):
         expected = {
             'type': 'listFiltered',
             'delegate': expected_dim_spec,
-            'values': ['val1', 'val2']
+            'values': ['val1', 'val2'],
         }
 
         assert actual == expected
@@ -111,7 +111,7 @@ class TestListFilteredSpec(object):
             'type': 'listFiltered',
             'delegate': expected_dim_spec,
             'values': ['val1', 'val2'],
-            'isWhitelist': False
+            'isWhitelist': False,
         }
 
         assert actual == expected
@@ -127,7 +127,7 @@ class TestRegexFilteredSpec(object):
         expected = {
             'type': 'regexFiltered',
             'delegate': expected_dim_spec,
-            'pattern': '\\w+'
+            'pattern': '\\w+',
         }
 
         assert actual == expected


### PR DESCRIPTION
Added support for Filtered DimensionSpecs as described [here](http://druid.io/docs/latest/querying/dimensionspecs.html#filtered-dimensionspecs). [Here](http://druid.io/docs/latest/querying/multi-value-dimensions.html#example-groupby-query-with-a-selector-query-filter-and-additional-filter-in-dimensions-attributes) is an example of how it is used for multi-value dimensions.