### PR TITLE
Support hyperUnique type

### DIFF
--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -28,6 +28,7 @@ type_map = {
     'bigint': types.BigInteger,
     'timestamp': types.TIMESTAMP,
     'date': types.DATE,
+    'other': types.BLOB,
 }
 
 


### PR DESCRIPTION
Druid has a column type `hyperUnique` that can be used in `COUNT(DISTINCT $expr)`. I added a mapping between the column type so it shows up as a `BLOB` in SQLAlchemy.

I tested the code by running a query on a `hyperUnique` column, `session_id`:

```python
from sqlalchemy.engine import create_engine

engine = create_engine('druid+https://XXXXXXXXXX:443/druid/v2/sql/')
with engine.connect() as conn:
    res = conn.execute('SELECT COUNT(DISTINCT session_id) AS sessions FROM hive_query_logged')

print(list(res))
```