### PR TITLE
Fix empty result

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -186,8 +186,11 @@ class Cursor(object):
         # to consume the first row so that `description` is properly set, so
         # let's consume it and insert it back.
         results = self._stream_query(query)
-        first_row = next(results)
-        self._results = itertools.chain([first_row], results)
+        try:
+            first_row = next(results)
+            self._results = itertools.chain([first_row], results)
+        except StopIteration:
+            self._results = iter([])
 
         return self
 

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -36,7 +36,6 @@ class CursorTestSuite(unittest.TestCase):
         response.status_code = 200
         response.raw = BytesIO(b'[]')
         requests_post_mock.return_value = response
-        Row = namedtuple('Row', ['name'])
 
         cursor = Cursor('http://example.com/')
         cursor.execute('SELECT * FROM table')

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from collections import namedtuple
+from mock import patch
+import unittest
+
+from requests.models import Response
+from six import BytesIO
+
+from pydruid.db.api import Cursor
+
+
+class CursorTestSuite(unittest.TestCase):
+
+    @patch('requests.post')
+    def test_execute(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b'[{"name": "alice"}, {"name": "bob"}, {"name": "charlie"}]')
+        requests_post_mock.return_value = response
+        Row = namedtuple('Row', ['name'])
+
+        cursor = Cursor('http://example.com/')
+        cursor.execute('SELECT * FROM table')
+        result = cursor.fetchall()
+        expected = [
+            Row(name='alice'),
+            Row(name='bob'),
+            Row(name='charlie'),
+        ]
+        self.assertEquals(result, expected)
+
+    @patch('requests.post')
+    def test_execute_empty_result(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b'[]')
+        requests_post_mock.return_value = response
+        Row = namedtuple('Row', ['name'])
+
+        cursor = Cursor('http://example.com/')
+        cursor.execute('SELECT * FROM table')
+        result = cursor.fetchall()
+        expected = []
+        self.assertEquals(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The DB API will stream the results from Druid, yielding data as soon as it's read from the network. In order to get the cursor description describing the results, the first row is read, the cursor is set, and the row is chained back to the results.

Unfortunately, this fails when there are no rows, raising a `StopIteration` exception. I changed the code to return an empty list instead. I also added two unit tests for the cursor, that can be expanded in the future.