### PR TITLE
Reserve original column sequence in SQL when reading data

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -328,7 +328,7 @@ def rows_from_chunks(chunks):
         rows = body[:boundary].lstrip('[,')
         body = body[boundary:]
 
-        for row in json.loads('[{rows}]'.format(rows=rows), 
+        for row in json.loads('[{rows}]'.format(rows=rows),
                               object_pairs_hook=OrderedDict):
             yield row
 

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 import itertools
 import json
 from six import string_types
@@ -328,7 +328,7 @@ def rows_from_chunks(chunks):
         rows = body[:boundary].lstrip('[,')
         body = body[boundary:]
 
-        for row in json.loads('[{rows}]'.format(rows=rows)):
+        for row in json.loads('[{rows}]'.format(rows=rows), object_pairs_hook=OrderedDict):
             yield row
 
 

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -328,7 +328,8 @@ def rows_from_chunks(chunks):
         rows = body[:boundary].lstrip('[,')
         body = body[boundary:]
 
-        for row in json.loads('[{rows}]'.format(rows=rows), object_pairs_hook=OrderedDict):
+        for row in json.loads('[{rows}]'.format(rows=rows), 
+                              object_pairs_hook=OrderedDict):
             yield row
 
 


### PR DESCRIPTION
Dear, 

I found that after pydruid read data, the sequence of columns is different with what user input in SQL,

This patch reserve original column sequence when reading data from chunk, so that column sequence will be same as what user inputed in SQL.

Please help to review this and if possible help to merge this.

