### PR TITLE
SubQueries Support

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -170,6 +170,59 @@ class BaseDruidClient(object):
         query = self.query_builder.timeseries(kwargs)
         return self._post(query)
 
+    def sub_query(self,**kwargs):
+        """
+        donot do a post here just return the dict..
+
+                Example:
+
+        .. code-block:: python
+            :linenos:
+
+                >>> subquery_json = client.subquery(
+                        datasource=twitterstream,
+                        granularity='hour',
+                        intervals='2018-01-01/2018-05-31',
+                        dimensions=["dim_key"],
+                        filter=\
+                        (Dimension('user_lang') == 'en') &
+                        (Dimension('user_name') == 'ram'),
+                        aggregations=\
+                            aggregations={"first_value": doublefirst("data_stream"),
+                            "last_value": doublelast("data_stream")},
+                        post_aggregations=\
+                            {'final_value': (HyperUniqueCardinality('last_value') -
+                             HyperUniqueCardinality('first_value'))})
+                    )
+                >>> print subquery_json
+                >>> {'query': {'aggregations': [{'fieldName': 'stream_value',
+                    'name': 'first_value',
+                    'type': 'doubleFirst'},
+                   {'fieldName': 'stream_value', 'name': 'last_value', 'type': 'doubleLast'}],
+                  'dataSource': 'twitterstream',
+                  'dimensions': ['dim_key'],
+                  'filter': {'fields': [{'dimension': 'user_lang',
+                     'type': 'selector',
+                     'value': 'en'},
+                    {'dimension': 'user_name', 'type': 'selector', 'value': 'ram'}],
+                   'type': 'and'},
+                  'granularity': 'hour',
+                  'intervals': '2018-01-01/2018-05-31',
+                  'postAggregations': [{'fields': [{'fieldName': 'last_value',
+                      'type': 'hyperUniqueCardinality'},
+                     {'fieldName': 'first_value', 'type': 'hyperUniqueCardinality'}],
+                    'fn': '-',
+                    'name': 'final_value',
+                    'type': 'arithmetic'}],
+                  'queryType': 'groupBy'},
+                 'type': 'query'}
+
+        :param kwargs:
+        :return:
+        """
+        query = self.query_builder.subquery(kwargs)
+        return query
+
     def groupby(self, **kwargs):
         """
         A group-by query groups a results set (the requested aggregate

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -199,7 +199,7 @@ class BaseDruidClient(object):
                     'name': 'first_value',
                     'type': 'doubleFirst'},
                    {'fieldName': 'stream_value', 'name': 'last_value', 'type':
-                   'doubleLast'}], 
+                   'doubleLast'}],
                   'dataSource': 'twitterstream',
                   'dimensions': ['dim_key'],
                   'filter': {'fields': [{'dimension': 'user_lang',

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -170,7 +170,7 @@ class BaseDruidClient(object):
         query = self.query_builder.timeseries(kwargs)
         return self._post(query)
 
-    def sub_query(self,**kwargs):
+    def sub_query(self, **kwargs):
         """
         donot do a post here just return the dict..
 
@@ -198,7 +198,8 @@ class BaseDruidClient(object):
                 >>> {'query': {'aggregations': [{'fieldName': 'stream_value',
                     'name': 'first_value',
                     'type': 'doubleFirst'},
-                   {'fieldName': 'stream_value', 'name': 'last_value', 'type': 'doubleLast'}],
+                   {'fieldName': 'stream_value', 'name': 'last_value', 'type':
+                   'doubleLast'}], 
                   'dataSource': 'twitterstream',
                   'dimensions': ['dim_key'],
                   'filter': {'fields': [{'dimension': 'user_lang',

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -362,6 +362,25 @@ class QueryBuilder(object):
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)
 
+    def subquery(self, args):
+        """
+        donot do a post here just return the dict..
+
+        :param dict args: dict of args
+
+        :rtype: json
+        """
+        query_type = 'groupBy'
+        valid_parts = [
+            'datasource', 'granularity', 'filter', 'aggregations',
+            'having', 'post_aggregations', 'intervals', 'dimensions',
+            'limit_spec',
+        ]
+        self.validate_query(query_type, valid_parts, args)
+        interim_query = self.build_query(query_type, args)
+        final_query = {"type": "query","query": interim_query.__dict__['query_dict']}
+        return final_query
+
     def segment_metadata(self, args):
         """
         * Column type

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -378,7 +378,7 @@ class QueryBuilder(object):
         ]
         self.validate_query(query_type, valid_parts, args)
         interim_query = self.build_query(query_type, args)
-        final_query = {"type": "query","query": interim_query.__dict__['query_dict']}
+        final_query = {"type": "query", "query": interim_query.__dict__['query_dict']}
         return final_query
 
     def segment_metadata(self, args):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -260,5 +260,3 @@ class TestQuery:
         assert isinstance(query[0], dict)
         assert isinstance(query[1], dict)
 
-    def test_subquery(self):
-

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -203,7 +203,6 @@ class TestQueryBuilder:
                 }],
                 'filter': {'dimension': 'one', 'type': 'selector', 'value': 1},
                 'having': {'aggregation': 'sum', 'type': 'greaterThan', 'value': 1},
-                'new_key': 'value',
             },
             'type': 'query'
         }
@@ -226,7 +225,6 @@ class TestQueryBuilder:
             },
             'filter': filters.Dimension('one') == 1,
             'having': having.Aggregation('sum') > 1,
-            'new_key': 'value',
         })
 
         # then

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -184,6 +184,53 @@ class TestQueryBuilder:
         with pytest.raises(ValueError):
             query = builder.build_query(None, builder_dict)
 
+    def test_build_subquery(self):
+        # given
+        expected_query_dict = {
+            'query': {
+                'queryType': 'groupBy',
+                'dataSource': 'things',
+                'aggregations': [{'fieldName': 'thing', 'name': 'count', 'type': 'count'}],
+                'postAggregations': [{
+                    'fields': [{
+                        'fieldName': 'sum', 'type': 'fieldAccess',
+                    }, {
+                        'fieldName': 'count', 'type': 'fieldAccess',
+                    }],
+                    'fn': '/',
+                    'name': 'avg',
+                    'type': 'arithmetic',
+                }],
+                'filter': {'dimension': 'one', 'type': 'selector', 'value': 1},
+                'having': {'aggregation': 'sum', 'type': 'greaterThan', 'value': 1},
+                'new_key': 'value',
+            },
+            'type': 'query'
+        }
+
+        builder = QueryBuilder()
+
+        # when
+        subquery_dict = builder.subquery({
+            'datasource': 'things',
+            'aggregations': {
+                'count': aggregators.count('thing'),
+            },
+            'post_aggregations': {
+                'avg': (postaggregator.Field('sum') /
+                        postaggregator.Field('count')),
+            },
+            'paging_spec': {
+                'pagingIdentifies': {},
+                'threshold': 1,
+            },
+            'filter': filters.Dimension('one') == 1,
+            'having': having.Aggregation('sum') > 1,
+            'new_key': 'value',
+        })
+
+        # then
+        assert subquery_dict == expected_query_dict
 
 
 class TestQuery:
@@ -212,3 +259,6 @@ class TestQuery:
         assert len(query) == 2
         assert isinstance(query[0], dict)
         assert isinstance(query[1], dict)
+
+    def test_subquery(self):
+

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -219,10 +219,6 @@ class TestQueryBuilder:
                 'avg': (postaggregator.Field('sum') /
                         postaggregator.Field('count')),
             },
-            'paging_spec': {
-                'pagingIdentifies': {},
-                'threshold': 1,
-            },
             'filter': filters.Dimension('one') == 1,
             'having': having.Aggregation('sum') > 1,
         })


### PR DESCRIPTION
Subquery support on druid.
Example:-
```
group = query.groupby(
    datasource=query.sub_query(datasource='twitterstream',
            granularity='hour',
            intervals='2018-01-01/2018-05-31',
            dimensions=["dim_key", "dim_key2"],
            filter=(Dimension('user_lang') == 'en') & (Dimension('user_name') == 'ram'),
            aggregations={"first_value": doublefirst("stream_value"),"last_value": doublelast("stream_value")},
            post_aggregations={'final_value': (HyperUniqueCardinality('last_value') - HyperUniqueCardinality('first_value'))}
    ),
    granularity='day',
    intervals='2018-01-01/2018-05-31',
    dimensions=["dim_key"],
    aggregations={"outer_final_value": doublesum("final_value")}
)

```