### PR TITLE
[prompt_toolkit] Enforcing pre-2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
     "pandas": ["pandas"],
     "async": ["tornado"],
     "sqlalchemy": ["sqlalchemy"],
-    "cli": ["pygments", "prompt_toolkit", "tabulate"],
+    "cli": ["pygments", "prompt_toolkit<2.0.0", "tabulate"],
 }
 
 # only require simplejson on python < 2.6


### PR DESCRIPTION
This PR resolves https://github.com/druid-io/pydruid/issues/134 as [prompt_toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/330ba727eceea98bc83dd4454d460ac4f05f86f8/docs/pages/upgrading.rst) introduced breaking changes in version 2.0.

Tested by ensuring that the CLI was functional via, 
```
> pip install -e .[cli]
> pydruid
``` 

to: @betodealmeida @mistercrunch 