### PR TITLE
[db-api] Performance improvements

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -220,7 +220,7 @@ class Cursor(object):
         no more rows are available.
         """
         size = size or self.arraysize
-        return list(itertools.islice(self, size))
+        return list(itertools.islice(self._results, size))
 
     @check_result
     @check_closed
@@ -230,7 +230,7 @@ class Cursor(object):
         sequence of sequences (e.g. a list of tuples). Note that the cursor's
         arraysize attribute can affect the performance of this operation.
         """
-        return list(self)
+        return list(self._results)
 
     @check_closed
     def setinputsizes(self, sizes):


### PR DESCRIPTION
This PR improves the performance of `fetchall` and `fetchmany` by iterating on the result set rather than iterating over the cursor's iterator. The following,

```python
import timeit

from pydruid.db.api import Cursor


def execute(self, operation, parameters=None):
    self._results = iter(range(10000))


Cursor.execute = execute


def test():
    cursor = Cursor(url=None)
    cursor.execute(operation=None)
    cursor.fetchall()


print(timeit.timeit("test()", number=1000, setup="from __main__ import test"))
```
resulted in an execution time of 6.698s and 0.331s for the current and proposed solutions respectively, i.e., the proposed solution is about 20x faster.

to: @betodealmeida @mistercrunch 