### PR TITLE
[console] Adding UNION ALL keyword

### DIFF
--- a/pydruid/console.py
+++ b/pydruid/console.py
@@ -31,6 +31,7 @@ keywords = [
     'ASC',
     'DESC',
     'LIMIT',
+    'UNION ALL',
 ]
 
 aggregate_functions = [


### PR DESCRIPTION
Adding the `UNION ALL` keyword which is supported in [Druid SQL](http://druid.io/docs/latest/querying/sql.html).

to: @betodealmeida @mistercrunch 