### PR TITLE
scan query: use columns instead of dimensions

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -439,7 +439,7 @@ class QueryBuilder(object):
         """
         query_type = 'scan'
         valid_parts = [
-            'datasource', 'granularity', 'filter', 'dimensions', 'metrics',
+            'datasource', 'granularity', 'filter', 'columns', 'metrics',
             'intervals', 'limit',
         ]
         self.validate_query(query_type, valid_parts, args)


### PR DESCRIPTION
Scan queries use the columns parameter (string array) to define the
dimension to return [1]. Currently, pydruid is incorrectly filling a
dimensions parameter, which ends up being ignored (and the scan query
always return all dimensions).

[1] http://druid.io/docs/latest/querying/scan-query.html

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>