### PR TITLE
Add support for Druid Basic Auth to SQLAlchemy

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -107,13 +107,10 @@ class Connection(object):
         port=8082,
         path='/druid/v2/sql/',
         scheme='http',
-<<<<<<< HEAD
+        user=None,
+        password=None,
         context=None,
         header=False,
-=======
-        user='',
-        password='',
->>>>>>> Add support for Druid Basic Auth to SQLAlchemy
     ):
         netloc = '{host}:{port}'.format(host=host, port=port)
         self.url = parse.urlunparse(
@@ -121,12 +118,9 @@ class Connection(object):
         self.context = context or {}
         self.closed = False
         self.cursors = []
-<<<<<<< HEAD
         self.header = header
-=======
         self.user = user
         self.password = password
->>>>>>> Add support for Druid Basic Auth to SQLAlchemy
 
     @check_closed
     def close(self):
@@ -150,11 +144,8 @@ class Connection(object):
     @check_closed
     def cursor(self):
         """Return a new Cursor Object using the connection."""
-<<<<<<< HEAD
-        cursor = Cursor(self.url, self.context, self.header)
-=======
-        cursor = Cursor(self.url, self.user, self.password)
->>>>>>> Add support for Druid Basic Auth to SQLAlchemy
+        cursor = Cursor(self.url, self.user, self.password, self.context,
+                        self.header)
         self.cursors.append(cursor)
 
         return cursor
@@ -175,17 +166,14 @@ class Cursor(object):
 
     """Connection cursor."""
 
-<<<<<<< HEAD
-    def __init__(self, url, context=None, header=False):
+    def __init__(self, url, user=None, password=None, context=None,
+                 header=False):
         self.url = url
         self.context = context or {}
         self.header = header
-=======
-    def __init__(self, url, user='', password=''):
         self.url = url
         self.user = user
         self.password = password
->>>>>>> Add support for Druid Basic Auth to SQLAlchemy
 
         # This read/write attribute specifies the number of rows to fetch at a
         # time with .fetchmany(). It defaults to 1 meaning to fetch a single
@@ -304,7 +292,6 @@ class Cursor(object):
         self.description = None
 
         headers = {'Content-Type': 'application/json'}
-<<<<<<< HEAD
 
         payload = {
             'query': query,
@@ -312,13 +299,10 @@ class Cursor(object):
             'header': self.header,
         }
 
-        r = requests.post(self.url, stream=True, headers=headers, json=payload)
-=======
-        payload = {'query': query}
-        auth = requests.auth.HTTPBasicAuth(self.user, self.password)
+        auth = requests.auth.HTTPBasicAuth(self.user,
+                                           self.password) if self.user else None
         r = requests.post(self.url, stream=True, headers=headers, json=payload,
                           auth=auth)
->>>>>>> Add support for Druid Basic Auth to SQLAlchemy
         if r.encoding is None:
             r.encoding = 'utf-8'
         # raise any error messages

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -25,6 +25,8 @@ def connect(
         port=8082,
         path='/druid/v2/sql/',
         scheme='http',
+        user=None,
+        password=None,
         context=None,
         header=False,
     ):  # noqa: E125
@@ -36,7 +38,7 @@ def connect(
 
     """
     context = context or {}
-    return Connection(host, port, path, scheme, context, header)
+    return Connection(host, port, path, scheme, user, password, context, header)
 
 
 def check_closed(f):
@@ -105,8 +107,13 @@ class Connection(object):
         port=8082,
         path='/druid/v2/sql/',
         scheme='http',
+<<<<<<< HEAD
         context=None,
         header=False,
+=======
+        user='',
+        password='',
+>>>>>>> Add support for Druid Basic Auth to SQLAlchemy
     ):
         netloc = '{host}:{port}'.format(host=host, port=port)
         self.url = parse.urlunparse(
@@ -114,7 +121,12 @@ class Connection(object):
         self.context = context or {}
         self.closed = False
         self.cursors = []
+<<<<<<< HEAD
         self.header = header
+=======
+        self.user = user
+        self.password = password
+>>>>>>> Add support for Druid Basic Auth to SQLAlchemy
 
     @check_closed
     def close(self):
@@ -138,7 +150,11 @@ class Connection(object):
     @check_closed
     def cursor(self):
         """Return a new Cursor Object using the connection."""
+<<<<<<< HEAD
         cursor = Cursor(self.url, self.context, self.header)
+=======
+        cursor = Cursor(self.url, self.user, self.password)
+>>>>>>> Add support for Druid Basic Auth to SQLAlchemy
         self.cursors.append(cursor)
 
         return cursor
@@ -159,10 +175,17 @@ class Cursor(object):
 
     """Connection cursor."""
 
+<<<<<<< HEAD
     def __init__(self, url, context=None, header=False):
         self.url = url
         self.context = context or {}
         self.header = header
+=======
+    def __init__(self, url, user='', password=''):
+        self.url = url
+        self.user = user
+        self.password = password
+>>>>>>> Add support for Druid Basic Auth to SQLAlchemy
 
         # This read/write attribute specifies the number of rows to fetch at a
         # time with .fetchmany(). It defaults to 1 meaning to fetch a single
@@ -281,6 +304,7 @@ class Cursor(object):
         self.description = None
 
         headers = {'Content-Type': 'application/json'}
+<<<<<<< HEAD
 
         payload = {
             'query': query,
@@ -289,6 +313,12 @@ class Cursor(object):
         }
 
         r = requests.post(self.url, stream=True, headers=headers, json=payload)
+=======
+        payload = {'query': query}
+        auth = requests.auth.HTTPBasicAuth(self.user, self.password)
+        r = requests.post(self.url, stream=True, headers=headers, json=payload,
+                          auth=auth)
+>>>>>>> Add support for Druid Basic Auth to SQLAlchemy
         if r.encoding is None:
             r.encoding = 'utf-8'
         # raise any error messages

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -95,8 +95,8 @@ class DruidDialect(default.DefaultDialect):
     name = 'druid'
     scheme = 'http'
     driver = 'rest'
-    user = ''
-    password = ''
+    user = None
+    password = None
     preparer = DruidIdentifierPreparer
     statement_compiler = DruidCompiler
     type_compiler = DruidTypeCompiler
@@ -122,8 +122,8 @@ class DruidDialect(default.DefaultDialect):
         kwargs = {
             'host': url.host,
             'port': url.port or 8082,
-            'user': url.username or '',
-            'password': url.password or '',
+            'user': url.username or None,
+            'password': url.password or None,
             'path': url.database,
             'scheme': self.scheme,
             'context': self.context,

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -95,6 +95,8 @@ class DruidDialect(default.DefaultDialect):
     name = 'druid'
     scheme = 'http'
     driver = 'rest'
+    user = ''
+    password = ''
     preparer = DruidIdentifierPreparer
     statement_compiler = DruidCompiler
     type_compiler = DruidTypeCompiler
@@ -120,6 +122,8 @@ class DruidDialect(default.DefaultDialect):
         kwargs = {
             'host': url.host,
             'port': url.port or 8082,
+            'user': url.username or '',
+            'password': url.password or '',
             'path': url.database,
             'scheme': self.scheme,
             'context': self.context,

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -54,11 +54,12 @@ class CursorTestSuite(unittest.TestCase):
         query = 'SELECT * FROM table'
         context = {'source': 'unittest'}
 
-        cursor = Cursor(url, context)
+        cursor = Cursor(url, user=None, password=None, context=context)
         cursor.execute(query)
 
         requests_post_mock.assert_called_with(
             'http://example.com/',
+            auth=None,
             stream=True,
             headers={'Content-Type': 'application/json'},
             json={'query': query, 'context': context, 'header': False},


### PR DESCRIPTION
This adds support for basic authentication (in the same
format as the other sqlalchemy drivers)
`druid://USER:PASSWORD@localhost:8082/druid/v2/sql/`

Signed-off-by: Don Bowman <don@agilicus.com>