### PR TITLE
Improve error message

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -273,8 +273,8 @@ class Cursor(object):
                 payload = r.json()
             except Exception as e:
                 payload = {
-                    'error': str(e),
-                    'errorClass': e.__class__.__name__,
+                    'error': 'Unknown error',
+                    'errorClass': 'Unknown',
                     'errorMessage': r.text,
                 }
             msg = (

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -269,7 +269,14 @@ class Cursor(object):
 
         # raise any error messages
         if r.status_code != 200:
-            payload = r.json()
+            try:
+                payload = r.json()
+            except Exception as e:
+                payload = {
+                    'error': str(e),
+                    'errorClass': e.__class__.__name__,
+                    'errorMessage': r.text,
+                }
             msg = (
                 '{error} ({errorClass}): {errorMessage}'.format(**payload)
             )

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -271,7 +271,7 @@ class Cursor(object):
         if r.status_code != 200:
             try:
                 payload = r.json()
-            except Exception as e:
+            except Exception:
                 payload = {
                     'error': 'Unknown error',
                     'errorClass': 'Unknown',


### PR DESCRIPTION
The response from errors in Druid is not necessarily JSON. I changed the error handling to handle error messages that are not JSON, like a timeout.