### PR TITLE
Pass context to Druid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 *~
 .tox
 env
+venv

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -21,12 +21,12 @@ class Type(object):
 
 
 def connect(
-        host='localhost',
-        port=8082,
-        path='/druid/v2/sql/',
-        scheme='http',
-        context=None,
-    ):
+    host='localhost',
+    port=8082,
+    path='/druid/v2/sql/',
+    scheme='http',
+    context=None,
+        ):
     """
     Constructor for creating a connection to the database.
 

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -20,7 +20,13 @@ class Type(object):
     BOOLEAN = 3
 
 
-def connect(host='localhost', port=8082, path='/druid/v2/sql/', scheme='http'):
+def connect(
+        host='localhost',
+        port=8082,
+        path='/druid/v2/sql/',
+        scheme='http',
+        context=None,
+    ):
     """
     Constructor for creating a connection to the database.
 
@@ -28,7 +34,8 @@ def connect(host='localhost', port=8082, path='/druid/v2/sql/', scheme='http'):
         >>> curs = conn.cursor()
 
     """
-    return Connection(host, port, path, scheme)
+    context = context or {}
+    return Connection(host, port, path, scheme, context)
 
 
 def check_closed(f):
@@ -97,10 +104,12 @@ class Connection(object):
         port=8082,
         path='/druid/v2/sql/',
         scheme='http',
+        context=None,
     ):
         netloc = '{host}:{port}'.format(host=host, port=port)
         self.url = parse.urlunparse(
             (scheme, netloc, path, None, None, None))
+        self.context = context or {}
         self.closed = False
         self.cursors = []
 
@@ -126,7 +135,7 @@ class Connection(object):
     @check_closed
     def cursor(self):
         """Return a new Cursor Object using the connection."""
-        cursor = Cursor(self.url)
+        cursor = Cursor(self.url, self.context)
         self.cursors.append(cursor)
 
         return cursor
@@ -147,8 +156,9 @@ class Cursor(object):
 
     """Connection cursor."""
 
-    def __init__(self, url):
+    def __init__(self, url, context=None):
         self.url = url
+        self.context = context or {}
 
         # This read/write attribute specifies the number of rows to fetch at a
         # time with .fetchmany(). It defaults to 1 meaning to fetch a single
@@ -262,7 +272,7 @@ class Cursor(object):
         self.description = None
 
         headers = {'Content-Type': 'application/json'}
-        payload = {'query': query}
+        payload = {'query': query, 'context': self.context}
         r = requests.post(self.url, stream=True, headers=headers, json=payload)
         if r.encoding is None:
             r.encoding = 'utf-8'

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -108,6 +108,10 @@ class DruidDialect(default.DefaultDialect):
     description_encoding = None
     supports_native_boolean = True
 
+    def __init__(self, context=None, *args, **kwargs):
+        super(DruidDialect, self).__init__(*args, **kwargs)
+        self.context = context or {}
+
     @classmethod
     def dbapi(cls):
         return pydruid.db
@@ -118,6 +122,7 @@ class DruidDialect(default.DefaultDialect):
             'port': url.port or 8082,
             'path': url.database,
             'scheme': self.scheme,
+            'context': self.context,
         }
         return ([], kwargs)
 

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -43,6 +43,27 @@ class CursorTestSuite(unittest.TestCase):
         expected = []
         self.assertEquals(result, expected)
 
+    @patch('requests.post')
+    def test_context(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b'[]')
+        requests_post_mock.return_value = response
+
+        url = 'http://example.com/'
+        query = 'SELECT * FROM table'
+        context = {'source': 'unittest'}
+
+        cursor = Cursor(url, context)
+        cursor.execute(query)
+
+        requests_post_mock.assert_called_with(
+            'http://example.com/',
+            stream=True,
+            headers={'Content-Type': 'application/json'},
+            json={'query': query, 'context': context},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Druid accepts a `context` object when being queried, eg:

```python
{
  "query" : "SELECT COUNT(*) FROM data_source WHERE foo = 'bar' AND __time > TIMESTAMP '2000-01-01 00:00:00'",
  "context" : {
        "user": "amalakar@lyft.com",
        "source": "superset",
        "user_id": "google_325325",
        "user_id_type": "google"
  }
}
```

I add a hook for passing a context object either in the SQL Alchemy connection or the Python DB API connection. I also added a unit test.