### PR TITLE
[api] Adding support for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ pip install pydruid[sqlalchemy]
 # or, if you want to use the CLI
 pip install pydruid[cli]
 ```
-Documentation: https://pythonhosted.org/pydruid/. 
+Documentation: https://pythonhosted.org/pydruid/.
 
 # examples
 
 The following exampes show how to execute and analyze the results of three types of queries: timeseries, topN, and groupby. We will use these queries to ask simple questions about twitter's public data set.
 
-## timeseries 
+## timeseries
 
 What was the average tweet length, per day, surrounding the 2014 Sochi olympics?
 
@@ -52,7 +52,7 @@ plt.show()
 
 ![alt text](https://github.com/metamx/pydruid/raw/master/docs/figures/avg_tweet_length.png "Avg. tweet length")
 
-## topN 
+## topN
 
 Who were the top ten mentions (@user_name) during the 2014 Oscars?
 
@@ -162,7 +162,7 @@ def your_asynchronous_method_serving_top10_mentions_for_day(day
 
 # thetaSketches
 Theta sketch Post aggregators are built slightly differently to normal Post Aggregators, as they have different operators.
-Note: you must have the ```druid-datasketches``` extension loaded into your Druid cluster in order to use these. 
+Note: you must have the ```druid-datasketches``` extension loaded into your Druid cluster in order to use these.
 See the [Druid datasketches](http://druid.io/docs/latest/development/extensions-core/datasketches-aggregators.html) documentation for details.
 
 ```python
@@ -212,7 +212,7 @@ curs.execute("""
 for row in curs:
     print(row)
 ```
-        
+
 # SQLAlchemy
 
 ```python
@@ -227,6 +227,27 @@ engine = create_engine('druid://localhost:8082/druid/v2/sql/')  # uses HTTP by d
 places = Table('places', MetaData(bind=engine), autoload=True)
 print(select([func.count('*')], from_obj=places).scalar())
 ```
+
+
+## Column headers
+
+In version 0.13.0 Druid SQL added support for including the column names in the
+response which can be requested via the "header" field in the request. This
+helps to ensure that the cursor description is defined (which is a requirement
+for SQLAlchemy query statements) regardless on whether the result set contains
+any rows. Historically this was problematic for result sets which contained no
+rows at one could not infer the expected column names.
+
+Enabling the header can be configured via the SQLAlchemy URI by using the query
+parameter, i.e.,
+
+```python
+engine = create_engine('druid://localhost:8082/druid/v2/sql?header=true')
+```
+
+Note the current default is `false` to ensure backwards compatibility but should
+be set to `true` for Druid versions >= 0.13.0.
+
 
 # Command line
 

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -123,6 +123,7 @@ class DruidDialect(default.DefaultDialect):
             'path': url.database,
             'scheme': self.scheme,
             'context': self.context,
+            'header': url.query.get('header') == 'true',
         }
         return ([], kwargs)
 

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -61,8 +61,46 @@ class CursorTestSuite(unittest.TestCase):
             'http://example.com/',
             stream=True,
             headers={'Content-Type': 'application/json'},
-            json={'query': query, 'context': context},
+            json={'query': query, 'context': context, 'header': False},
         )
+
+    @patch('requests.post')
+    def test_header_false(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b'[{"name": "alice"}]')
+        requests_post_mock.return_value = response
+        Row = namedtuple('Row', ['name'])
+
+        url = 'http://example.com/'
+        query = 'SELECT * FROM table'
+
+        cursor = Cursor(url, header=False)
+        cursor.execute(query)
+        result = cursor.fetchall()
+        self.assertEquals(result, [Row(name='alice')])
+
+        self.assertEquals(
+            cursor.description,
+            [('name', 1, None, None, None, None, True)],
+        )
+
+    @patch('requests.post')
+    def test_header_true(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b'[{"name": null}, {"name": "alice"}]')
+        requests_post_mock.return_value = response
+        Row = namedtuple('Row', ['name'])
+
+        url = 'http://example.com/'
+        query = 'SELECT * FROM table'
+
+        cursor = Cursor(url, header=True)
+        cursor.execute(query)
+        result = cursor.fetchall()
+        self.assertEquals(result, [Row(name='alice')])
+        self.assertEquals(cursor.description, [('name', None)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR closes https://github.com/druid-io/pydruid/issues/151 by providing a mechanism for specifying whether the [Druid SQL](http://druid.io/docs/latest/querying/sql) response should include a header (added in 0.13.0) which contains the column names. 

Note the default behavior remains unchanged, i.e., headers are not requested. Including the `headers` field in the request body is not problematic for older versions of Druid which are agnostic of this option.

to: @betodealmeida 