### PR TITLE
 Support for search and like filters

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -78,6 +78,14 @@ class Filter:
         elif type_ == "extraction":
             self.filter["filter"].update({"dimension": args["dimension"],
                                           "value": args["value"]})
+        elif type_ == "search":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "query": {"type": "contains", "value": args["value"],
+                                                    "caseSensitive": args.get("caseSensitive", "false")}}
+                                         )
+        elif type_ == "like":
+            self.filter["filter"].update({"dimension": args["dimension"],
+                                          "pattern": args["pattern"]})            
         else:
             raise NotImplementedError(
                 'Filter type: {0} does not exist'.format(type_))

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -79,13 +79,15 @@ class Filter:
             self.filter["filter"].update({"dimension": args["dimension"],
                                           "value": args["value"]})
         elif type_ == "search":
-            self.filter["filter"].update({"dimension": args["dimension"],
-                                          "query": {"type": "contains", "value": args["value"],
-                                                    "caseSensitive": args.get("caseSensitive", "false")}}
-                                         )
+            self.filter["filter"].update({
+                "dimension": args["dimension"],
+                "query": {"type": "contains",
+                          "value": args["value"],
+                          "caseSensitive": args.get("caseSensitive", "false")}
+            })
         elif type_ == "like":
             self.filter["filter"].update({"dimension": args["dimension"],
-                                          "pattern": args["pattern"]})            
+                                          "pattern": args["pattern"]})
         else:
             raise NotImplementedError(
                 'Filter type: {0} does not exist'.format(type_))

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -240,3 +240,25 @@ class TestFilter:
                 {'type': 'default', 'dimension': 'dim2', 'outputName': 'dim2'}
             ]}
         assert actual == expected
+
+    def test_search_filter(self):
+        # Without caseSensitive param - default:false
+        actual = filters.Filter.build_filter(
+            filters.Filter(type="search", dimension="dim", value='val'))
+        expected = {'type': 'search', 'dimension': 'dim',
+                    'query': {'type': 'contains', 'caseSensitive': 'false', 'value': 'val'}}
+        assert actual == expected
+
+        # With caseSensitive param
+        actual = filters.Filter.build_filter(
+            filters.Filter(type="search", dimension="dim", value='val', caseSensitive='true'))
+        expected = {'type': 'search', 'dimension': 'dim',
+                    'query': {'type': 'contains', 'caseSensitive': 'true', 'value': 'val'}}
+        assert actual == expected
+
+    def test_like_filter(self):
+        actual = filters.Filter.build_filter(
+            filters.Filter(type="like", dimension="dim", pattern="%val%"))
+        expected = {'type': 'like', 'dimension': 'dim', 'pattern': '%val%'}
+        assert actual == expected
+        


### PR DESCRIPTION
Added new filters "search" and "like" filters.
Usage:
```
group = query.groupby(
    datasource="wikipedia",
    ......
    ...
    filter= Filter(type="search", dimension="user", value='AZ', caseSensitive='true') 
                   &        Filter(type="like", dimension="dim", pattern="John%"),
    ....
    .......
   
)
```
More Info : http://druid.io/docs/latest/querying/filters.html
