### PR TITLE
F timeout issue 140

### DIFF
--- a/pydruid/async_client.py
+++ b/pydruid/async_client.py
@@ -39,6 +39,7 @@ class AsyncPyDruid(BaseDruidClient):
 
     :param str url: URL of Broker node in the Druid cluster
     :param str endpoint: Endpoint that Broker listens for queries on
+    :param dict defaults: (optional) Dict of parameters for the Async HTTP Client subclass
 
     Example
 
@@ -95,11 +96,13 @@ class AsyncPyDruid(BaseDruidClient):
                 1      6  2013-10-04T00:00:00.000Z         user_2
     """
 
-    def __init__(self, url, endpoint):
+    def __init__(self, url, endpoint, defaults=None):
         super(AsyncPyDruid, self).__init__(url, endpoint)
+        self.async_http_defaults = defaults
 
     @gen.coroutine
     def _post(self, query):
+        AsyncHTTPClient.configure(None, defaults=self.async_http_defaults)
         http_client = AsyncHTTPClient()
         try:
             headers, querystr, url = self._prepare_url_headers_and_body(query)


### PR DESCRIPTION
Added the ability to pass default parameters to the AsyncHTTPClient class.  This allows the request or connect timeout parameters to be changed as well as other parameters.  I needed to increase the request timeout for some of our group-by queries to Druid.