### PR TITLE
Don't throw away error messages from Druid

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -490,11 +490,12 @@ class PyDruid(BaseDruidClient):
             res.close()
         except urllib.error.HTTPError as e:
             err = e.reason
-            if e.code == 500:
+            if e.code in [400, 500]:
                 # has Druid returned an error?
                 try:
-                    err = json.loads(err)
-                except ValueError:
+                    body = e.read()
+                    err = json.loads(body)
+                except (ValueError, KeyError):
                     if HTML_ERROR.search(err):
                         err = HTML_ERROR.search(err).group(1)
                 except (ValueError, AttributeError, KeyError):


### PR DESCRIPTION
In certain cases, Druid will return an error message in JSON format in
the body of the HTTP response.  However, PyDruid would attempt to
parse the HTTP reason phrase as JSON instead, which wouldn't succeed
as it is something like "Bad Request" and "Server Error".  Fix this by
parsing the response body instead.

Also do the same thing for error code 400 ("bad request"), not just
500.  For "bad request" errors, there is usually a clue as to what's
wrong with the query in the error message, so it's worth displaying
the error message instead of discarding it.
