### PR TITLE
Parse actual response body for HTTP error

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -489,7 +489,7 @@ class PyDruid(BaseDruidClient):
             data = res.read().decode("utf-8")
             res.close()
         except urllib.error.HTTPError as e:
-            err = e.reason
+            err = e.read()
             if e.code == 500:
                 # has Druid returned an error?
                 try:


### PR DESCRIPTION
Before:
```
           OSError: HTTP Error 500: Internal Server Error 
            Druid Error: Internal Server Error 
            Query is: {
...
```

After:
```
           OSError: HTTP Error 500: Internal Server Error 
            Druid Error: {'error': 'Unknown exception', 'errorMessage': "Instantiation of [simple type, class org.apache.druid.query.groupby.GroupByQuery] value failed: querySegmentSpec can't be null", 'errorClass': 'com.fasterxml.jackson.databind.JsonMappingException', 'host': None} 
            Query is: {
...
```