### PR TITLE
Allow config of http client implementation

### DIFF
--- a/pydruid/async_client.py
+++ b/pydruid/async_client.py
@@ -40,6 +40,8 @@ class AsyncPyDruid(BaseDruidClient):
     :param str url: URL of Broker node in the Druid cluster
     :param str endpoint: Endpoint that Broker listens for queries on
     :param dict defaults: (optional) Dict of parameters for the Async HTTP Client subclass
+    :param str http_client: Tornado HTTP client implementation to use.
+        Default: None (use simple_httpclient)
 
     Example
 
@@ -96,13 +98,14 @@ class AsyncPyDruid(BaseDruidClient):
                 1      6  2013-10-04T00:00:00.000Z         user_2
     """
 
-    def __init__(self, url, endpoint, defaults=None):
+    def __init__(self, url, endpoint, defaults=None, http_client=None):
         super(AsyncPyDruid, self).__init__(url, endpoint)
         self.async_http_defaults = defaults
+        self.http_client = http_client
 
     @gen.coroutine
     def _post(self, query):
-        AsyncHTTPClient.configure(None, defaults=self.async_http_defaults)
+        AsyncHTTPClient.configure(self.http_client, defaults=self.async_http_defaults)
         http_client = AsyncHTTPClient()
         try:
             headers, querystr, url = self._prepare_url_headers_and_body(query)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -142,3 +142,25 @@ class TestAsyncPyDruid(AsyncHTTPTestCase):
         self.assertIsNotNone(top)
         self.assertEqual(len(top.result), 1)
         self.assertEqual(len(top.result[0]['result']), 1)
+
+    @tornado.testing.gen_test
+    def test_client_allows_passing_http_client(self):
+        # given
+        client = AsyncPyDruid("http://localhost:%s" % (self.get_http_port(), ),
+                              "druid/v2/return_results",
+                              http_client="tornado.curl_httpclient.CurlAsyncHTTPClient")
+        top = yield client.topn(
+                datasource="testdatasource",
+                granularity="all",
+                intervals="2015-12-29/pt1h",
+                aggregations={"count": doublesum("count")},
+                dimension="user_name",
+                metric="count",
+                filter=Dimension("user_lang") == "en",
+                threshold=1,
+                context={"timeout": 1000})
+
+        # then
+        self.assertIsNotNone(top)
+        self.assertEqual(len(top.result), 1)
+        self.assertEqual(len(top.result[0]['result']), 1)


### PR DESCRIPTION
Issue #162 
Add the ability to use a different http client such as the curl_httpclient which can be faster.  An optional parameter was added to the class init which defaults to None, meaning using the default simple_httpclient.  To use curl_httpclient, set the parameter http_client to the value "tornado.curl_httpclient.CurlAsyncHTTPClient".  AsyncHTTPClient.configure is then called with the appropriate http_client value before instantiating AsyncHTTPClient.