### PR TITLE
Updated bound filter to latest Druid API specs

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -68,6 +68,7 @@ class Filter:
                 "lowerStrict": args["lowerStrict"],
                 "upper": args["upper"],
                 "upperStrict": args["upperStrict"],
+                "alphaNumeric": args["alphaNumeric"],
                 "ordering": args["ordering"]
             })
         elif type_ == "columnComparison":
@@ -164,13 +165,16 @@ class Bound(Filter):
     :ivar str upper: Upper bound.
     :ivar bool lowerStrict: Strict lower inclusion. Initial value: False
     :ivar bool upperStrict: Strict upper inclusion. Initial value: False
+    :ivar bool alphaNumeric: Numeric comparison. Initial value: False
+        NOTE: For backwards compatibility - Use "ordering" instead.
     :ivar bool ordering: Sorting Order. Initial value: lexicographic
     :ivar ExtractionFunction extraction_function: extraction function to use,
                                                   if not None
     """
     def __init__(
             self, dimension, lower=None, upper=None, lowerStrict=False,
-            upperStrict=False, ordering="lexicographic", extraction_function=None):
+            upperStrict=False, alphaNumeric=False, ordering="lexicographic",
+            extraction_function=None):
         if not lower and not upper:
             raise ValueError("Must include either lower or upper or both")
         Filter.__init__(
@@ -178,7 +182,8 @@ class Bound(Filter):
             type='bound', dimension=dimension,
             lower=lower, upper=upper,
             lowerStrict=lowerStrict, upperStrict=upperStrict,
-            ordering=ordering, extraction_function=extraction_function)
+            alphaNumeric=alphaNumeric, ordering=ordering,
+            extraction_function=extraction_function)
 
 
 class Interval(Filter):

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -68,7 +68,7 @@ class Filter:
                 "lowerStrict": args["lowerStrict"],
                 "upper": args["upper"],
                 "upperStrict": args["upperStrict"],
-                "alphaNumeric": args["alphaNumeric"]
+                "ordering": args["ordering"]
             })
         elif type_ == "columnComparison":
             self.filter['filter'].update({'dimensions': args['dimensions']})
@@ -164,19 +164,21 @@ class Bound(Filter):
     :ivar str upper: Upper bound.
     :ivar bool lowerStrict: Strict lower inclusion. Initial value: False
     :ivar bool upperStrict: Strict upper inclusion. Initial value: False
-    :ivar bool alphaNumeric: Numeric comparison. Initial value: False
+    :ivar bool ordering: Sorting Order. Initial value: lexicographic
     :ivar ExtractionFunction extraction_function: extraction function to use,
                                                   if not None
     """
     def __init__(
-            self, dimension, lower, upper, lowerStrict=False,
-            upperStrict=False, alphaNumeric=False, extraction_function=None):
+            self, dimension, lower=None, upper=None, lowerStrict=False,
+            upperStrict=False, ordering="lexicographic", extraction_function=None):
+        if not lower and not upper:
+            raise ValueError("Must include either lower or upper or both")
         Filter.__init__(
             self,
             type='bound', dimension=dimension,
             lower=lower, upper=upper,
             lowerStrict=lowerStrict, upperStrict=upperStrict,
-            alphaNumeric=alphaNumeric, extraction_function=extraction_function)
+            ordering=ordering, extraction_function=extraction_function)
 
 
 class Interval(Filter):

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -55,8 +55,10 @@ class TestFilter:
 
     def test_bound_filter(self):
         actual = filters.Filter.build_filter(
-            filters.Bound(dimension='dim', lower='1', lowerStrict=True, upper='10', upperStrict=True, alphaNumeric=True))
-        expected = {'type': 'bound', 'dimension': 'dim', 'lower': '1', 'lowerStrict': True, 'upper': '10', 'upperStrict': True, 'alphaNumeric': True}
+            filters.Bound(dimension='dim', lower='1', lowerStrict=True,
+                          upper='10', upperStrict=True, ordering="numeric"))
+        expected = {'type': 'bound', 'dimension': 'dim', 'lower': '1',
+                    'lowerStrict': True, 'upper': '10', 'upperStrict': True, 'ordering': 'numeric'}
         assert actual == expected
 
     def test_bound_filter_with_extraction_function(self):
@@ -66,8 +68,8 @@ class TestFilter:
         actual = filters.Filter.build_filter(f)
         expected = {'type': 'bound', 'dimension': 'd', 'lower': '1',
                     'lowerStrict': False, 'upper': '3', 'upperStrict': True,
-                    'alphaNumeric': False, 'extractionFn': {
-                        'type': 'regex', 'expr': '.*([0-9]+)'}}
+                    'ordering': 'lexicographic',
+                    'extractionFn': {'type': 'regex', 'expr': '.*([0-9]+)'}}
         assert actual == expected
 
 

--- a/tests/utils/test_filters.py
+++ b/tests/utils/test_filters.py
@@ -58,7 +58,8 @@ class TestFilter:
             filters.Bound(dimension='dim', lower='1', lowerStrict=True,
                           upper='10', upperStrict=True, ordering="numeric"))
         expected = {'type': 'bound', 'dimension': 'dim', 'lower': '1',
-                    'lowerStrict': True, 'upper': '10', 'upperStrict': True, 'ordering': 'numeric'}
+                    'lowerStrict': True, 'upper': '10', 'upperStrict': True,
+                    'alphaNumeric': False, 'ordering': 'numeric'}
         assert actual == expected
 
     def test_bound_filter_with_extraction_function(self):
@@ -68,10 +69,26 @@ class TestFilter:
         actual = filters.Filter.build_filter(f)
         expected = {'type': 'bound', 'dimension': 'd', 'lower': '1',
                     'lowerStrict': False, 'upper': '3', 'upperStrict': True,
-                    'ordering': 'lexicographic',
+                    'ordering': 'lexicographic', 'alphaNumeric': False,
                     'extractionFn': {'type': 'regex', 'expr': '.*([0-9]+)'}}
         assert actual == expected
 
+    def test_bound_filter_alphanumeric(self):
+        actual = filters.Filter.build_filter(
+            filters.Bound(dimension='dim', lower='1', lowerStrict=True,
+                          upper='10', upperStrict=True, alphaNumeric=True))
+        expected = {'type': 'bound', 'dimension': 'dim', 'lower': '1',
+                    'lowerStrict': True, 'upper': '10', 'upperStrict': True,
+                    'alphaNumeric': True, 'ordering': 'lexicographic'}
+        assert actual == expected
+
+    def test_bound_filter_lower_not_included(self):
+        actual = filters.Filter.build_filter(
+            filters.Bound(dimension='dim', upper='10', upperStrict=True))
+        expected = {'type': 'bound', 'dimension': 'dim', 'lower': None,
+                    'lowerStrict': False, 'upper': '10', 'upperStrict': True,
+                    'alphaNumeric': False, 'ordering': 'lexicographic'}
+        assert actual == expected
 
     def test_interval_filter(self):
         actual = filters.Filter.build_filter(


### PR DESCRIPTION
Updated the Bound class and Filter class with the correct parameter name for latest version of Druid.  Changed "alphanumeric" to "ordering" and set the default to lexicographic based on API documentation.  Updated the Bound Filter tests with new parameter and executed all tests successfully.