### PR TITLE
[dbapi] Fixing application of parameters

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -205,7 +205,7 @@ class Cursor(object):
 
     @check_closed
     def execute(self, operation, parameters=None):
-        query = apply_parameters(operation, parameters or {})
+        query = apply_parameters(operation, parameters)
         results = self._stream_query(query)
 
         # `_stream_query` returns a generator that produces the rows; we need to
@@ -380,6 +380,9 @@ def rows_from_chunks(chunks):
 
 
 def apply_parameters(operation, parameters):
+    if parameters is None:
+        return operation
+
     escaped_parameters = {
         key: escape(value) for key, value in parameters.items()
     }
@@ -391,9 +394,9 @@ def escape(value):
         return value
     elif isinstance(value, string_types):
         return "'{}'".format(value.replace("'", "''"))
-    elif isinstance(value, (int, float)):
-        return value
     elif isinstance(value, bool):
         return 'TRUE' if value else 'FALSE'
+    elif isinstance(value, (int, float)):
+        return value
     elif isinstance(value, (list, tuple)):
         return ', '.join(escape(element) for element in value)

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -7,7 +7,7 @@ import unittest
 from requests.models import Response
 from six import BytesIO
 
-from pydruid.db.api import Cursor
+from pydruid.db.api import apply_parameters, Cursor
 
 
 class CursorTestSuite(unittest.TestCase):
@@ -119,6 +119,37 @@ class CursorTestSuite(unittest.TestCase):
         result = cursor.fetchall()
         self.assertEquals(result, [Row(_0='alice')])
         self.assertEquals(cursor.description, [('_name', None)])
+
+    def test_apply_parameters(self):
+        self.assertEquals(
+            apply_parameters('SELECT 100 AS "100%"', None),
+            'SELECT 100 AS "100%"',
+        )
+
+        self.assertEquals(
+            apply_parameters('SELECT %(key)s AS "100%%"', {'key': 100}),
+            'SELECT 100 AS "100%"',
+        )
+
+        self.assertEquals(
+            apply_parameters('SELECT %(key)s', {'key': '*'}),
+            'SELECT *',
+        )
+
+        self.assertEquals(
+            apply_parameters('SELECT %(key)s', {'key': 'bar'}),
+            "SELECT 'bar'",
+        )
+
+        self.assertEquals(
+            apply_parameters('SELECT %(key)s', {'key': True}),
+            'SELECT TRUE',
+        )
+
+        self.assertEquals(
+            apply_parameters('SELECT %(key)s', {'key': False}),
+            'SELECT FALSE',
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes an issue where the SQL statement contains a `%` character (possibly in an alias) where and when no parameters are specified the following is problematic, 

```
>>> 'SELECT 100 AS "100%"' % {}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: unsupported format character '"' (0x22) at index 19
```

The fix uses the same logic as  [PyHive](https://github.com/dropbox/PyHive/blob/v0.6.1/pyhive/presto.py#L191) and only formats the operation (using the pyformat convention) if parameters exist. 

Additionally it resolves an issue which surfaced by adding unit tests caused by the fact that a `bool` is an instance of `int`, i.e., 

```
>>> x = True
>>> isinstance(x, int)
True
```

and thus booleans weren't being escaped correctly. 

to: @betodealmeida @mistercrunch 