### PR TITLE
[dbapi] Fixing type ordering

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -88,7 +88,12 @@ def get_description_from_row(row):
 
 
 def get_type(value):
-    """Infer type from value."""
+    """
+    Infer type from value.
+
+    Note that bool is a subclass of int so order of statements matter.
+    """
+
     if isinstance(value, string_types) or value is None:
         return Type.STRING
     elif isinstance(value, bool):
@@ -383,6 +388,12 @@ def apply_parameters(operation, parameters):
 
 
 def escape(value):
+    """
+    Escape the parameter value.
+
+    Note that bool is a subclass of int so order of statements matter.
+    """
+
     if value == "*":
         return value
     elif isinstance(value, string_types):

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -91,10 +91,10 @@ def get_type(value):
     """Infer type from value."""
     if isinstance(value, string_types) or value is None:
         return Type.STRING
-    elif isinstance(value, (int, float)):
-        return Type.NUMBER
     elif isinstance(value, bool):
         return Type.BOOLEAN
+    elif isinstance(value, (int, float)):
+        return Type.NUMBER
 
     raise exceptions.Error("Value of unknown type: {value}".format(value=value))
 


### PR DESCRIPTION
Similar to https://github.com/druid-io/pydruid/pull/171 this PR ensures that the type check for the more restrictive boolean occurs before the check for numeric type as `isinstance(True, (int, float))` evaluates to `True`. 

to: @betodealmeida @mistercrunch 

