### PR TITLE
[dbapi] Fix empty parameter check

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -375,7 +375,7 @@ def rows_from_chunks(chunks):
 
 
 def apply_parameters(operation, parameters):
-    if parameters is None:
+    if not parameters:
         return operation
 
     escaped_parameters = {key: escape(value) for key, value in parameters.items()}

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -127,6 +127,11 @@ class CursorTestSuite(unittest.TestCase):
         )
 
         self.assertEquals(
+            apply_parameters('SELECT 100 AS "100%"', {}),
+            'SELECT 100 AS "100%"',
+        )
+
+        self.assertEquals(
             apply_parameters('SELECT %(key)s AS "100%%"', {'key': 100}),
             'SELECT 100 AS "100%"',
         )


### PR DESCRIPTION
This PR is a refinement of https://github.com/druid-io/pydruid/pull/171 where the check for parameters is loosened to be anything which is falsy. This is needed as libraries like Pandas passes an empty dictionary (as opposed to `None`) if no parameters are defined. 

to: @betodealmeida @mistercrunch 