### PR TITLE
[dbapi] Remove duplicate line

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -170,7 +170,6 @@ class Cursor(object):
         self.url = url
         self.context = context or {}
         self.header = header
-        self.url = url
         self.user = user
         self.password = password
 


### PR DESCRIPTION
This PR removes the duplicate definition of `self.url` which was introduced in https://github.com/druid-io/pydruid/pull/149.

to: @donbowman @mistercrunch 