### PR TITLE
Fixed typo in docstring for Bound class

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -193,7 +193,8 @@ class Bound(Filter):
         Specifies the sorting order to use when comparing values against the bound.
         Can be one of the following values: "lexicographic", "alphanumeric", "numeric",
         "strlen", "version". See Sorting Orders
-        (https://druid.apache.org/docs/latest/querying/filters.html#bound-filter) for more details.
+        https://druid.apache.org/docs/latest/querying/filters.html#bound-filter
+        for more details.
     :ivar ExtractionFunction extraction_function: extraction function to use,
                                                   if not None
     """

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -189,7 +189,7 @@ class Bound(Filter):
     :ivar bool upperStrict: Strict upper inclusion. Initial value: False
     :ivar bool alphaNumeric: Numeric comparison. Initial value: False
         NOTE: For backwards compatibility - Use "ordering" instead.
-    :ivar bool ordering: Sorting Order. Initial value: lexicographic
+    :ivar str ordering: Sorting Order. Initial value: lexicographic
     :ivar ExtractionFunction extraction_function: extraction function to use,
                                                   if not None
     """

--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -190,6 +190,10 @@ class Bound(Filter):
     :ivar bool alphaNumeric: Numeric comparison. Initial value: False
         NOTE: For backwards compatibility - Use "ordering" instead.
     :ivar str ordering: Sorting Order. Initial value: lexicographic
+        Specifies the sorting order to use when comparing values against the bound.
+        Can be one of the following values: "lexicographic", "alphanumeric", "numeric",
+        "strlen", "version". See Sorting Orders
+        (https://druid.apache.org/docs/latest/querying/filters.html#bound-filter) for more details.
     :ivar ExtractionFunction extraction_function: extraction function to use,
                                                   if not None
     """


### PR DESCRIPTION
Updated docstring for Bound class in filters.py to fix incorrect variable type.  Changed from bool to str.