### PR TITLE
support order in query component (scan)

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -512,6 +512,7 @@ class QueryBuilder(object):
             "metrics",
             "intervals",
             "limit",
+            "order"
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)


### PR DESCRIPTION
http://druid.apache.org/docs/latest/querying/scan-query.html

After reading doc, I found that scan query support ordering by __time but the current version does not support it yet.