### PR TITLE
Update connect function in api.py to accept proxies

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -21,16 +21,16 @@ class Type(object):
 
 
 def connect(
-        host="localhost",
-        port=8082,
-        path="/druid/v2/sql/",
-        scheme="http",
-        user=None,
-        password=None,
-        context=None,
-        header=False,
-        ssl_verify_cert=True,
-        proxies=None,
+    host="localhost",
+    port=8082,
+    path="/druid/v2/sql/",
+    scheme="http",
+    user=None,
+    password=None,
+    context=None,
+    header=False,
+    ssl_verify_cert=True,
+    proxies=None,
 ):  # noqa: E125
     """
     Constructor for creating a connection to the database.
@@ -42,17 +42,17 @@ def connect(
     context = context or {}
 
     return Connection(
-                host,
-                port,
-                path,
-                scheme,
-                user,
-                password,
-                context,
-                header,
-                ssl_verify_cert,
-                proxies,
-            )
+        host,
+        port,
+        path,
+        scheme,
+        user,
+        password,
+        context,
+        header,
+        ssl_verify_cert,
+        proxies,
+    )
 
 
 def check_closed(f):
@@ -169,14 +169,14 @@ class Connection(object):
         """Return a new Cursor Object using the connection."""
 
         cursor = Cursor(
-                    self.url,
-                    self.user,
-                    self.password,
-                    self.context,
-                    self.header,
-                    self.ssl_verify_cert,
-                    self.proxies,
-                )
+            self.url,
+            self.user,
+            self.password,
+            self.context,
+            self.header,
+            self.ssl_verify_cert,
+            self.proxies,
+        )
 
         self.cursors.append(cursor)
 
@@ -197,7 +197,6 @@ class Connection(object):
 class Cursor(object):
     """Connection cursor."""
 
-
     def __init__(
         self,
         url,
@@ -212,8 +211,7 @@ class Cursor(object):
         self.context = context or {}
         self.header = header
         self.user = user
-        self.password = password        
-
+        self.password = password
         self.ssl_verify_cert = ssl_verify_cert
         self.proxies = proxies
 
@@ -339,8 +337,6 @@ class Cursor(object):
             requests.auth.HTTPBasicAuth(self.user, self.password) if self.user else None
         )
         r = requests.post(
-            self.url, stream=True, headers=headers, json=payload, auth=auth,
-            proxies=self.proxies
             self.url,
             stream=True,
             headers=headers,
@@ -420,7 +416,7 @@ def rows_from_chunks(chunks):
         body = body[boundary:]
 
         for row in json.loads(
-                "[{rows}]".format(rows=rows), object_pairs_hook=OrderedDict
+            "[{rows}]".format(rows=rows), object_pairs_hook=OrderedDict
         ):
             yield row
 

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -21,15 +21,15 @@ class Type(object):
 
 
 def connect(
-    host="localhost",
-    port=8082,
-    path="/druid/v2/sql/",
-    scheme="http",
-    user=None,
-    password=None,
-    context=None,
-    header=False,
-    proxies=None
+        host="localhost",
+        port=8082,
+        path="/druid/v2/sql/",
+        scheme="http",
+        user=None,
+        password=None,
+        context=None,
+        header=False,
+        proxies=None
 ):  # noqa: E125
     """
     Constructor for creating a connection to the database.
@@ -106,20 +106,19 @@ def get_type(value):
 
 
 class Connection(object):
-
     """Connection to a Druid database."""
 
     def __init__(
-        self,
-        host="localhost",
-        port=8082,
-        path="/druid/v2/sql/",
-        scheme="http",
-        user=None,
-        password=None,
-        context=None,
-        header=False,
-        proxies=None
+            self,
+            host="localhost",
+            port=8082,
+            path="/druid/v2/sql/",
+            scheme="http",
+            user=None,
+            password=None,
+            context=None,
+            header=False,
+            proxies=None
     ):
         netloc = "{host}:{port}".format(host=host, port=port)
         self.url = parse.urlunparse((scheme, netloc, path, None, None, None))
@@ -153,7 +152,8 @@ class Connection(object):
     @check_closed
     def cursor(self):
         """Return a new Cursor Object using the connection."""
-        cursor = Cursor(self.url, self.user, self.password, self.context, self.header, self.proxies)
+        cursor = Cursor(self.url, self.user, self.password, self.context, self.header,
+                        self.proxies)
         self.cursors.append(cursor)
 
         return cursor
@@ -171,16 +171,16 @@ class Connection(object):
 
 
 class Cursor(object):
-
     """Connection cursor."""
 
-    def __init__(self, url, user=None, password=None, context=None, header=False, proxies=None):
+    def __init__(self, url, user=None, password=None, context=None, header=False,
+                 proxies=None):
         self.url = url
         self.context = context or {}
         self.header = header
         self.user = user
         self.password = password
-        self.proxies=None
+        self.proxies = proxies
 
         # This read/write attribute specifies the number of rows to fetch at a
         # time with .fetchmany(). It defaults to 1 meaning to fetch a single
@@ -304,7 +304,8 @@ class Cursor(object):
             requests.auth.HTTPBasicAuth(self.user, self.password) if self.user else None
         )
         r = requests.post(
-            self.url, stream=True, headers=headers, json=payload, auth=auth, proxies=proxies
+            self.url, stream=True, headers=headers, json=payload, auth=auth,
+            proxies=self.proxies
         )
         if r.encoding is None:
             r.encoding = "utf-8"
@@ -377,7 +378,7 @@ def rows_from_chunks(chunks):
         body = body[boundary:]
 
         for row in json.loads(
-            "[{rows}]".format(rows=rows), object_pairs_hook=OrderedDict
+                "[{rows}]".format(rows=rows), object_pairs_hook=OrderedDict
         ):
             yield row
 

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -63,6 +63,7 @@ class CursorTestSuite(unittest.TestCase):
             stream=True,
             headers={'Content-Type': 'application/json'},
             json={'query': query, 'context': context, 'header': False},
+            proxies=None
         )
 
     @patch('requests.post')


### PR DESCRIPTION
In certain scenarios, druid url's are accessible explicitly through proxies, so added proxies as input parameter for connection which is passed to requests.post in Cursor

@donbowman @mistercrunch can you please review this PR?