### PR TITLE
[fix] Ensuring export_pandas returns a pandas.DataFrame

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -198,8 +198,9 @@ class Query(collections.MutableSequence):
                     "type: {0}".format(self.query_type)
                 )
 
-            df = pandas.DataFrame(nres)
-            return df
+            return pandas.DataFrame(nres)
+
+        return pandas.DataFrame()
 
     def __str__(self):
         return str(self.result)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -243,7 +243,11 @@ class TestQuery:
         query = create_query_with_results()
         df = query.export_pandas()
         expected_df = pandas.DataFrame(EXPECTED_RESULTS_PANDAS)
-        assert_frame_equal(df, expected_df)
+        assert_frame_equal(df, expected_df, check_like=True)
+
+        query = Query({}, 'timeseries')
+        df = query.export_pandas()
+        assert_frame_equal(df, pandas.DataFrame())
 
     def test_query_acts_as_a_wrapper_for_raw_result(self):
         # given
@@ -253,4 +257,3 @@ class TestQuery:
         assert len(query) == 2
         assert isinstance(query[0], dict)
         assert isinstance(query[1], dict)
-


### PR DESCRIPTION
Per the docstring the [`export_pandas`](https://github.com/druid-io/pydruid/blob/80cf6fe767817c8c30e908ea2e145bee09aa6d9b/pydruid/query.py#L132) method returns an object of type `pandas.DataFrame` however the return type was also `None` if no results were defined. 

You can't simply check a `pandas.DataFrame` for truthiness and thus the following isn't valid,

```
df = client.export_pandas()

if df:
     ...
```

when you're returning a mix of `None` and `pandas.DataFrame`. Currently you would need to be the somewhat verbose:

```
df = client.export_pandas()

if df is not None and not df.empty():
     ...
```

This PR ensures the method always returns a `pandas.DataFrame` regardless of the results, i.e., one can simply use:

```
df = client.export_pandas()

if not df.empty():
     ...
```

to: @betodealmeida @mistercrunch 