### PR TITLE
Add project urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,12 @@ setup(
     author="Druid Developers",
     author_email="druid-development@googlegroups.com",
     packages=["pydruid", "pydruid.db", "pydruid.utils"],
-    url="https://pypi.python.org/pypi/pydruid/",
+    url="https://druid.apache.org",
+    project_urls={
+        "Bug Tracker": "https://github.com/druid-io/pydruid/issues",
+        "Documentation": "https://pythonhosted.org/pydruid/",
+        "Source Code": "https://github.com/druid-io/pydruid",
+    },
     license="Apache License, Version 2.0",
     description="A Python connector for Druid.",
     long_description=long_description,


### PR DESCRIPTION
Currently the Homepage link on the PyPI page is referencing the same page due to     `url="https://pypi.python.org/pypi/pydruid/"` in `setup.py`. By pointing `url` to the Apache Druid homepage and adding GitHub + documentation pages to `project_urls` the PyPI page can display useful links and statistics.

Screenshot below from Pandas PyPI page using the same properties in `setup.py`:

![image](https://user-images.githubusercontent.com/33317356/77061951-bd248000-69e3-11ea-93c4-361364e4545b.png)
