### PR TITLE
Add optional cert to request signature

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -30,7 +30,7 @@ def connect(
     context=None,
     header=False,
     ssl_verify_cert=True,
-    cert=None,
+    ssl_client_cert=None,
     proxies=None,
 ):  # noqa: E125
     """
@@ -52,7 +52,7 @@ def connect(
         context,
         header,
         ssl_verify_cert,
-        cert,
+        ssl_client_cert,
         proxies,
     )
 
@@ -134,7 +134,7 @@ class Connection(object):
         context=None,
         header=False,
         ssl_verify_cert=True,
-        cert=None,
+        ssl_client_cert=None,
         proxies=None,
     ):
         netloc = "{host}:{port}".format(host=host, port=port)
@@ -146,7 +146,7 @@ class Connection(object):
         self.user = user
         self.password = password
         self.ssl_verify_cert = ssl_verify_cert
-        self.cert = cert
+        self.ssl_client_cert = ssl_client_cert
         self.proxies = proxies
 
     @check_closed
@@ -179,7 +179,7 @@ class Connection(object):
             self.context,
             self.header,
             self.ssl_verify_cert,
-            self.cert,
+            self.ssl_client_cert,
             self.proxies,
         )
 
@@ -211,7 +211,7 @@ class Cursor(object):
         header=False,
         ssl_verify_cert=True,
         proxies=None,
-        cert=None,
+        ssl_client_cert=None,
     ):
         self.url = url
         self.context = context or {}
@@ -219,7 +219,7 @@ class Cursor(object):
         self.user = user
         self.password = password
         self.ssl_verify_cert = ssl_verify_cert
-        self.cert = cert
+        self.ssl_client_cert = ssl_client_cert
         self.proxies = proxies
 
         # This read/write attribute specifies the number of rows to fetch at a
@@ -350,7 +350,7 @@ class Cursor(object):
             json=payload,
             auth=auth,
             verify=self.ssl_verify_cert,
-            cert=self.cert,
+            cert=self.ssl_client_cert,
             proxies=self.proxies,
         )
         if r.encoding is None:

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -30,6 +30,7 @@ def connect(
     context=None,
     header=False,
     ssl_verify_cert=True,
+    cert=None,
     proxies=None,
 ):  # noqa: E125
     """
@@ -51,6 +52,7 @@ def connect(
         context,
         header,
         ssl_verify_cert,
+        cert,
         proxies,
     )
 
@@ -132,6 +134,7 @@ class Connection(object):
         context=None,
         header=False,
         ssl_verify_cert=True,
+        cert=None,
         proxies=None,
     ):
         netloc = "{host}:{port}".format(host=host, port=port)
@@ -143,6 +146,7 @@ class Connection(object):
         self.user = user
         self.password = password
         self.ssl_verify_cert = ssl_verify_cert
+        self.cert = cert
         self.proxies = proxies
 
     @check_closed
@@ -175,6 +179,7 @@ class Connection(object):
             self.context,
             self.header,
             self.ssl_verify_cert,
+            self.cert,
             self.proxies,
         )
 
@@ -206,6 +211,7 @@ class Cursor(object):
         header=False,
         ssl_verify_cert=True,
         proxies=None,
+        cert=None,
     ):
         self.url = url
         self.context = context or {}
@@ -213,6 +219,7 @@ class Cursor(object):
         self.user = user
         self.password = password
         self.ssl_verify_cert = ssl_verify_cert
+        self.cert = cert
         self.proxies = proxies
 
         # This read/write attribute specifies the number of rows to fetch at a
@@ -343,6 +350,7 @@ class Cursor(object):
             json=payload,
             auth=auth,
             verify=self.ssl_verify_cert,
+            cert=self.cert,
             proxies=self.proxies,
         )
         if r.encoding is None:

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -64,6 +64,7 @@ class CursorTestSuite(unittest.TestCase):
             headers={'Content-Type': 'application/json'},
             json={'query': query, 'context': context, 'header': False},
             verify=True,
+            cert=None,
             proxies=None,
         )
 


### PR DESCRIPTION
This adds the option to use a client certificate for requests. To facilitate this, the `cert` argument is added to the `connect()` method, which is passed through to the cursor and ultimately the `requests.post` call.

Docs: http://2.python-requests.org/en/v1.1.0/user/advanced/#ssl-cert-verification
