### PR TITLE
fix: make compatible with python 3.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       python: 3.6
     - env: TOXENV=py37
       python: 3.7
+    - env: TOXENV=py38
+      python: 3.8
 before_install:
    - sudo apt-get update
    - sudo apt-get install libgnutls28-dev

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -25,7 +25,7 @@ from pydruid.utils.postaggregator import Postaggregator
 from pydruid.utils.query_utils import UnicodeWriter
 
 
-class Query(collections.MutableSequence):
+class Query(collections.abc.MutableSequence):
     """
     Query objects are produced by PyDruid clients and can be used for
     exporting query results into TSV files or
@@ -54,7 +54,7 @@ class Query(collections.MutableSequence):
             self.result = res
         else:
             raise IOError(
-                "{Error parsing result: {0} for {1} query".format(
+                "Error parsing result: {0} for {1} query".format(
                     self.result_json, self.query_type
                 )
             )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black==19.3b0
+black==19.10b0
 flake8-mypy==17.8.0
-flake8==3.7.7
+flake8==3.8.2
 ipdb==0.12
 pip-tools==4.4.0
 pre-commit==1.17.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=install_requires,
     extras_require=extras_require,
-    setup_requires=["pytest-runner"],
     tests_require=["pytest", "six", "mock"],
     entry_points={
         "console_scripts": ["pydruid = pydruid.console:main"],
@@ -54,5 +53,6 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import namedtuple
-from mock import patch
+from unittest.mock import patch
 import unittest
 
 from requests.models import Response

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from mock import Mock
+from unittest.mock import Mock
 from pydruid.utils.aggregators import doublesum
 from pydruid.utils.filters import Dimension
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@
 import textwrap
 
 import pytest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from six.moves import urllib
 from six import StringIO
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ commands =
     pytest {posargs}
 deps =
     -rrequirements.txt
-    mock==3.0.5
-    pytest==4.6.9
+    pytest==5.4.3
 parallel_show_output = true
 usedevelop = true
 
@@ -12,13 +11,13 @@ usedevelop = true
 commands =
     black --check pydruid setup.py tests
 deps =
-    black>=19.3b0
+    black==19.10b0
 
 [testenv:flake8]
 commands =
     flake8 pydruid setup.py
 deps =
-    flake8==3.7.7
+    flake8==3.8.2
 
 [tox]
 envlist =


### PR DESCRIPTION
This fixes incompatibility with python 3.7 (both installation via `pip` and running tests via `pytest`) and fixes a deprecation warning + errors picked up by new versions of linters. Closes #198 