### PR TITLE
fix broken build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include *.md
-recursive-include docs
-recursive-include pydruid
+recursive-include docs *.txt
+recursive-include pydruid *.py
+global-exclude *.py[co]
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setup(
     version="0.999.0dev",
     author="Druid Developers",
     author_email="druid-development@googlegroups.com",
-    packages=find_packages("pydruid"),
-    package_dir={"": "pydruid"},
+    packages=find_packages(),
     url="https://druid.apache.org",
     project_urls={
         "Bug Tracker": "https://github.com/druid-io/pydruid/issues",


### PR DESCRIPTION
In a recent PR #218 aiming to exclude avoid accidentally packaging unwanted files in the build (secrets, `venv`, `.tox` etc), more strict inclusion rules were put in place. However, the PR also broke the build bu not including all important files.

This fix has been tested locally to work by:
- packaging the release by running `python setup.py sdist`.
- creating a fresh isolated virtualenv with only the dependencies from `requirements.txt` installed in addition to running `pip install pydruid-0.999.0.dev0.tar.gz` (created above) and running the `pydruid` unit tests (all tests completed). This was done with Python versions 3.6.10, 3.7.7 and 3.8.3.
- installed `pip install pydruid-0.999.0.dev0.tar.gz` on `master` branch of Apache Superset and connected to an Imply cluster + executing a few queries.

Closes #220