### PR TITLE
Add virtualColumns to valid_parts

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -340,6 +340,7 @@ class QueryBuilder(object):
             "dimension",
             "threshold",
             "metric",
+            "virtualColumns",
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)
@@ -363,6 +364,7 @@ class QueryBuilder(object):
             "descending",
             "post_aggregations",
             "intervals",
+            "virtualColumns",
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)
@@ -388,6 +390,7 @@ class QueryBuilder(object):
             "intervals",
             "dimensions",
             "limit_spec",
+            "virtualColumns",
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)


### PR DESCRIPTION
This doesn't add any helper functions for virtualColumns, but it adds the option to the list of `valid_parts` so that users may pass a manually created list in.