### PR TITLE
fix: Updating prompt-toolkit

### DIFF
--- a/pydruid/console.py
+++ b/pydruid/console.py
@@ -3,8 +3,8 @@ import re
 import sys
 from urllib import parse
 
-from prompt_toolkit import AbortAction, prompt
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit import prompt
+from prompt_toolkit.completion.word_completer import WordCompleter
 from prompt_toolkit.history import FileHistory
 from pygments.lexers import SqlLexer
 from pygments.style import Style
@@ -174,9 +174,8 @@ def main():
                 completer=sql_completer,
                 style=DocumentStyle,
                 history=history,
-                on_abort=AbortAction.RETRY,
             )
-        except EOFError:
+        except (EOFError, KeyboardInterrupt):
             break  # Control-D pressed.
 
         # run query

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
     "pandas": ["pandas"],
     "async": ["tornado"],
     "sqlalchemy": ["sqlalchemy"],
-    "cli": ["pygments", "prompt_toolkit", "tabulate"],
+    "cli": ["pygments", "prompt_toolkit>=2.0.0", "tabulate"],
 }
 
 with io.open("README.md", encoding="utf-8") as f:


### PR DESCRIPTION
This PR updates a number of import issues which surface with more recent versions of `prompt-toolkit`. In order to upgrade I simply adhered to the instructions [here](https://python-prompt-toolkit.readthedocs.io/en/master/pages/upgrading/2.0.html#upgrading).

to: @mistercrunch 