### PR TITLE
fix: compatible with python3.8

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-import collections
 import json
+from collections.abc import MutableSequence
 
 from pydruid.utils.aggregators import build_aggregators
 from pydruid.utils.dimensions import build_dimension
@@ -25,7 +25,7 @@ from pydruid.utils.postaggregator import Postaggregator
 from pydruid.utils.query_utils import UnicodeWriter
 
 
-class Query(collections.abc.MutableSequence):
+class Query(MutableSequence):
     """
     Query objects are produced by PyDruid clients and can be used for
     exporting query results into TSV files or


### PR DESCRIPTION
Since `abc` is a submodule in `collections` and not imported to collections, directly using `collections.abc.MutableSequence` will cause error in newer versions (I tested it on 3.8.5, but I think 3.7 may have the same issue):

```
>>> import collections
>>> collections.abc.MutableSequence
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/anlong/.homebrew/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/collections/__init__.py", line 55, in __getattr__
    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
AttributeError: module 'collections' has no attribute 'abc'
```

And the current code will cause this error: `python -c "from pydruid import client"`.

I think this issue was not found because if we run `import collections.abc` or `from collections.abc import x` before, the `collections.abc` will be added to `collections`. And many thrid party have codes like this.

But anyway, I think we should fix this.