### PR TITLE
Fix parameter ordering

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -204,8 +204,8 @@ class Cursor(object):
         context=None,
         header=False,
         ssl_verify_cert=True,
-        proxies=None,
         ssl_client_cert=None,
+        proxies=None,
     ):
         self.url = url
         self.context = context or {}


### PR DESCRIPTION
In line 49-50 the argument ordering is `ssl_client_cert,proxies`, this fixes the order of the params to match.