### PR TITLE
fix: visit_ methods raise CompileError exception childs

### DIFF
--- a/pydruid/db/exceptions.py
+++ b/pydruid/db/exceptions.py
@@ -1,3 +1,6 @@
+from sqlalchemy.ex import CompileError
+
+
 class Error(Exception):
     pass
 
@@ -34,5 +37,5 @@ class DataError(DatabaseError):
     pass
 
 
-class NotSupportedError(DatabaseError):
+class NotSupportedError(CompileError):
     pass

--- a/pydruid/db/exceptions.py
+++ b/pydruid/db/exceptions.py
@@ -1,4 +1,4 @@
-from sqlalchemy.ex import CompileError
+from sqlalchemy.exc import CompileError
 
 
 class Error(Exception):


### PR DESCRIPTION
Small proposal to change a parent class exception:

SQLAlchemy `visit_*` methods are traversed at compile SQL time, makes sense they raise a child of `CompileError`, so that applications don't have to make too broad exception catch.
