### PR TITLE
fix Bound filter's empty argument checking for 'lower' and 'upper'

### DIFF
--- a/pydruid/utils/filters.py
+++ b/pydruid/utils/filters.py
@@ -214,7 +214,7 @@ class Bound(Filter):
         ordering="lexicographic",
         extraction_function=None,
     ):
-        if not lower and not upper:
+        if lower is None and upper is None:
             raise ValueError("Must include either lower or upper or both")
         Filter.__init__(
             self,


### PR DESCRIPTION
Hi guys, I found a quite obvious bug when I use the `Bound` filter.

The minimum code to reproduce the bug is as below:

```python
from pydruid.utils.filters import Bound

# I want to select the rows that satisfy "foo >= 0"
Bound(dimension='foo', lower=0).show()
```

this will cause the following exception:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-76-afbba87ff9ee> in <module>
      1 from pydruid.utils.filters import Bound
----> 2 Bound(dimension='foo', lower=0).show()

~/Library/Python/3.7/lib/python/site-packages/pydruid/utils/filters.py in __init__(self, dimension, lower, upper, lowerStrict, upperStrict, alphaNumeric, ordering, extraction_function)
    216     ):
    217         if not lower and not upper:
--> 218             raise ValueError("Must include either lower or upper or both")
    219         Filter.__init__(
    220             self,

ValueError: Must include either lower or upper or both
```

But when I changed `lower=0` into `lower=1`, everything just went well:

```python
Bound(dimension='foo', lower=1).show()
```

output:

```txt
{
    "filter": {
        "type": "bound",
        "dimension": "foo",
        "lower": 1,
        "lowerStrict": false,
        "upper": null,
        "upperStrict": false,
        "alphaNumeric": false,
        "ordering": "lexicographic"
    }
}
```

Obviously, the root of the problem lies in line 217, which is to check whether argument `lower` and `upper` are both omitted:

```python
if not lower and not upper:
```

However, this checking unexpectedly blocked the number `0`, besides `None`. 

Changing this line into the line below should fix the bug:

```python
if lower is None and upper is None:
```