### PR TITLE
Fix backslash handling in rows_from_chunks

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -394,20 +394,27 @@ def rows_from_chunks(chunks):
             body = "".join((body, chunk))
 
         # find last complete row
+        # see also: https://www.json.org/
         boundary = 0
         brackets = 0
         in_string = False
+        in_escape = False
         for i, char in enumerate(body):
-            if char == '"':
-                if not in_string:
-                    in_string = True
-                elif body[i - 1] != "\\":
-                    in_string = False
-
             if in_string:
+                if in_escape:
+                    # we're just looking for string boundaries, so we can
+                    # ignore the trailing X in escapes like \uXXXX, since each
+                    # of those X characters must be alphanumeric anyway
+                    in_escape = False
+                elif char == '\\':
+                    in_escape = True
+                elif char == '"':
+                    in_string = False
                 continue
 
-            if char == "{":
+            if char == '"':
+                in_string = True
+            elif char == "{":
                 brackets += 1
             elif char == "}":
                 brackets -= 1

--- a/tests/db/test_rows_from_chunks.py
+++ b/tests/db/test_rows_from_chunks.py
@@ -36,6 +36,18 @@ class RowsFromChunksTestSuite(unittest.TestCase):
         result = list(rows_from_chunks(chunks))
         self.assertEqual(result, expected)
 
+    def test_rows_from_chunks_string_ending_with_backslash(self):
+        chunks = [r'[{"name": "\\"}]']
+        expected = [{"name": "\\"}]
+        result = list(rows_from_chunks(chunks))
+        self.assertEqual(result, expected)
+
+    def test_rows_from_chunks_multiple_rows_ending_with_backslashes(self):
+        chunks = [r'[{"name": "alice"}, {"name": "bob\\"}, {"name": "charlie\\"}]']
+        expected = [{"name": "alice"}, {"name": "bob\\"}, {"name": "charlie\\"}]
+        result = list(rows_from_chunks(chunks))
+        self.assertEqual(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This should fix #242.

In the `rows_from_chunks` function, when deciding whether or not a quote character indicates the end of a string, it only checked the preceding character to see if it was a backslash or not. But it didn't check if that backslash was escaped or not.

So, if a row contains a string with a properly escaped backslash right before the closing quote (e.g. `"\\"`), the row chunker will think that the closing quote is escaped. So then the number of braces it sees in the rest of the input won't be balanced, and then it won't ever properly process the rest of the JSON.

I changed `rows_from_chunks` to keep track of escaped character state in a string to avoid this, and added a couple of unit tests to check for this scenario.