### PR TITLE
Support infer type long from value

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -108,7 +108,7 @@ def get_type(value):
         return Type.STRING
     elif isinstance(value, bool):
         return Type.BOOLEAN
-    elif isinstance(value, (int, float)):
+    elif isinstance(value, (int, long, float)):
         return Type.NUMBER
 
     raise exceptions.Error("Value of unknown type: {value}".format(value=value))


### PR DESCRIPTION
For "SELECT TIMESTAMP_TO_MILLIS(__time) FROM foo", data type of the returned value is "long" for 32-bit Windows.