### PR TITLE
DB API - Adding support for dynamic parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ for row in curs:
 
 ## Dynamic Parameters
 
-Druid 0.18.0 introduced support for [Dynamic Parameters](https://druid.apache.org/docs/latest/querying/sql.html#dynamic-parameters) where parameters are bound to `?` placeholders at execution time. This can be set using `dynamic_parameters`. on `connect`.
+Druid 0.18.0 introduced support for [Dynamic Parameters](https://druid.apache.org/docs/latest/querying/sql.html#dynamic-parameters) where parameters are bound to `?` placeholders at execution time. Dynamic parameters can be optionally used by setting `dynamic_parameters` to `True` on `connect`.
 
-Parameters support the types below, additionally allowing for tuples and lists for convenience with each value coerced to the appropriate Druid type.
+Parameters support the instance types specified below, additionally allowing for tuples and lists for convenience with each value coerced to the appropriate Druid type.
 
 ```
 | Instance Type | Druid Type |

--- a/README.md
+++ b/README.md
@@ -213,6 +213,49 @@ for row in curs:
     print(row)
 ```
 
+## Dynamic Parameters
+
+Druid 0.18.0 introduced support for [Dynamic Parameters](https://druid.apache.org/docs/latest/querying/sql.html#dynamic-parameters) where parameters are bound to `?` placeholders at execution time. This can be set using `dynamic_parameters`. on `connect`.
+
+Parameters support the types below, additionally allowing for tuples and lists for convenience with each value coerced to the appropriate Druid type.
+
+```
+| Instance Type | Druid Type |
+|---------------|------------|
+| int           | INTEGER    |
+| float         | FLOAT      |
+| str           | VARCHAR    |
+| bool          | BOOLEAN    |
+```
+
+Example:
+
+```python
+from pydruid.db import connect
+
+conn = connect(host='localhost', port=8082, path='/druid/v2/sql/', scheme='http', dynamic_parameters=True)
+curs = conn.cursor()
+parameters = {
+    "start_dt": "2015-09-12 00:00:00",
+    "channels": ("#en.wikipedia", "#es.wikipedia"),
+    "added_gt": 10,
+}
+curs.execute("""
+     SELECT
+        channel,
+        page,
+        SUM(added)
+    FROM wikipedia
+    WHERE
+        __time >= TIMESTAMP %(start_dt)s
+    AND
+        channel IN (%(channels)s)
+    GROUP BY channel, page
+    ORDER BY SUM(added) DESC
+    HAVING SUM(added) >= %(added_gt)s
+""", parameters)
+```
+
 # SQLAlchemy
 
 ```python

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -486,11 +486,11 @@ def apply_dynamic_parameters(operation, parameters):
         else:
             values.append(parameters[op_parameter])
 
-    param_placements = {key: dynamic_placeholder(v) for key, v in parameters.items()}
+    placeholders = {key: dynamic_placeholder(v) for key, v in parameters.items()}
 
     dynamic_parameters = [dynamic_parameter(v) for v in values]
 
-    return operation % param_placements, dynamic_parameters
+    return operation % placeholders, dynamic_parameters
 
 
 def dynamic_parameter(value):

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -471,23 +471,22 @@ def apply_dynamic_parameters(operation, parameters):
     if not parameters:
         return operation, None
 
+    # Search for params in the following format `%(param_one)s`
     p = re.compile("%\\((.*?)\\)s")
     operation_parameters = p.findall(operation)
 
-    if set(parameters.keys()) != set(operation_parameters):
+    if set(parameters) != set(operation_parameters):
         raise exceptions.OperationalError("Parameters and placeholders do not match")
 
     values = []
 
     for op_parameter in operation_parameters:
         if isinstance(parameters[op_parameter], (tuple, list)):
-            values.extend(list(parameters[op_parameter]))
+            values.extend(parameters[op_parameter])
         else:
             values.append(parameters[op_parameter])
 
-    param_placements = {
-        key: dynamic_placeholder(value) for key, value in parameters.items()
-    }
+    param_placements = {key: dynamic_placeholder(v) for key, v in parameters.items()}
 
     dynamic_parameters = [dynamic_parameter(v) for v in values]
 

--- a/pydruid/db/exceptions.py
+++ b/pydruid/db/exceptions.py
@@ -1,6 +1,3 @@
-from sqlalchemy.exc import CompileError
-
-
 class Error(Exception):
     pass
 
@@ -37,5 +34,15 @@ class DataError(DatabaseError):
     pass
 
 
-class NotSupportedError(CompileError):
+support_error_child_cls = None
+
+try:
+    from sqlalchemy.exc import CompileError
+
+    support_error_child_cls = CompileError
+except ImportError:
+    support_error_child_cls = DatabaseError
+
+
+class NotSupportedError(support_error_child_cls):
     pass

--- a/pydruid/db/exceptions.py
+++ b/pydruid/db/exceptions.py
@@ -34,6 +34,8 @@ class DataError(DatabaseError):
     pass
 
 
+# Allow for the support of using `sqlalchemy.exc.CompileError` when using the
+# `extra_require` of sqlalchemy - implemented in #243
 support_error_child_cls = None
 
 try:

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -8,13 +8,12 @@ from unittest.mock import patch
 from requests.models import Response
 
 from pydruid.db.api import (
+    apply_dynamic_parameters,
     apply_parameters,
     Cursor,
-    apply_dynamic_parameters,
     dynamic_parameter,
     dynamic_placeholder,
 )
-
 from pydruid.db.exceptions import OperationalError
 
 

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -7,7 +7,15 @@ from unittest.mock import patch
 
 from requests.models import Response
 
-from pydruid.db.api import apply_parameters, Cursor
+from pydruid.db.api import (
+    apply_parameters,
+    Cursor,
+    apply_dynamic_parameters,
+    dynamic_parameter,
+    dynamic_placeholder,
+)
+
+from pydruid.db.exceptions import OperationalError
 
 
 class CursorTestSuite(unittest.TestCase):
@@ -146,6 +154,212 @@ class CursorTestSuite(unittest.TestCase):
         self.assertEqual(
             apply_parameters("SELECT %(key)s", {"key": False}), "SELECT FALSE"
         )
+
+    @patch("requests.post")
+    def test_execute_with_dynamic_parameter(self, requests_post_mock):
+        response = Response()
+        response.status_code = 200
+        response.raw = BytesIO(b"[]")
+        requests_post_mock.return_value = response
+
+        url = "http://example.com/"
+        parameters = {"name": "Druid"}
+        query = "SELECT * FROM table where name = %(name)s"
+
+        cursor = Cursor(url, user=None, password=None, dynamic_parameters=True)
+        cursor.execute(query, parameters)
+
+        assert_query = "SELECT * FROM table where name = ?"
+        assert_params = [{"value": "Druid", "type": "VARCHAR"}]
+
+        requests_post_mock.assert_called_with(
+            "http://example.com/",
+            auth=None,
+            stream=True,
+            headers={"Content-Type": "application/json"},
+            json={
+                "query": assert_query,
+                "parameters": assert_params,
+                "context": {},
+                "header": False,
+            },
+            verify=True,
+            cert=None,
+            proxies=None,
+        )
+
+    def test_apply_dynamic_parameters(self):
+
+        parameters = {
+            "start_dt": "2015-09-12 00:00:00",
+            "end_dt": "2015-09-13 00:00:00",
+            "channels": ("#en.wikipedia", "#es.wikipedia"),
+            "pages": ["Apache Druid", "Apache%"],
+            "added_gt": 10,
+        }
+
+        operation = """
+            SELECT
+                channel,
+                page,
+                SUM(added)
+            FROM wikipedia
+            WHERE
+                __time BETWEEN TIMESTAMP %(start_dt)s AND TIMESTAMP %(end_dt)s
+            AND
+                channel IN (%(channels)s)
+            AND
+                page IN (%(pages)s)
+            GROUP BY channel, page
+            ORDER BY SUM(added) DESC
+            HAVING SUM(added) >= %(added_gt)s
+        """
+
+        r_op, r_params = apply_dynamic_parameters(operation, parameters)
+
+        assert_op = """
+            SELECT
+                channel,
+                page,
+                SUM(added)
+            FROM wikipedia
+            WHERE
+                __time BETWEEN TIMESTAMP ? AND TIMESTAMP ?
+            AND
+                channel IN (?, ?)
+            AND
+                page IN (?, ?)
+            GROUP BY channel, page
+            ORDER BY SUM(added) DESC
+            HAVING SUM(added) >= ?
+        """
+
+        self.assertEqual(r_op, assert_op)
+
+        self.assertEqual(
+            (r_params[0]["value"], r_params[0]["type"]),
+            (parameters["start_dt"], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[1]["value"], r_params[1]["type"]),
+            (parameters["end_dt"], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[2]["value"], r_params[2]["type"]),
+            (parameters["channels"][0], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[3]["value"], r_params[3]["type"]),
+            (parameters["channels"][1], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[4]["value"], r_params[4]["type"]),
+            (parameters["pages"][0], "VARCHAR"),
+        )
+        self.assertEqual(
+            (r_params[5]["value"], r_params[5]["type"]),
+            (parameters["pages"][1], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[6]["value"], r_params[6]["type"]),
+            (parameters["added_gt"], "INTEGER"),
+        )
+
+    def test_apply_dynamic_parameters_out_of_order(self):
+
+        parameters = {
+            "channels": ("#en.wikipedia", "#es.wikipedia"),
+            "added_gt": 10,
+            "start_dt": "2015-09-12 00:00:00",
+        }
+
+        operation = """
+            SELECT
+                channel,
+                page,
+                SUM(added)
+            FROM wikipedia
+            WHERE
+                __time >= TIMESTAMP %(start_dt)s
+            AND
+                channel IN (%(channels)s)
+            GROUP BY channel, page
+            ORDER BY SUM(added) DESC
+            HAVING SUM(added) >= %(added_gt)s
+        """
+
+        r_op, r_params = apply_dynamic_parameters(operation, parameters)
+
+        assert_op = """
+            SELECT
+                channel,
+                page,
+                SUM(added)
+            FROM wikipedia
+            WHERE
+                __time >= TIMESTAMP ?
+            AND
+                channel IN (?, ?)
+            GROUP BY channel, page
+            ORDER BY SUM(added) DESC
+            HAVING SUM(added) >= ?
+        """
+
+        self.assertEqual(r_op, assert_op)
+
+        self.assertEqual(
+            (r_params[0]["value"], r_params[0]["type"]),
+            (parameters["start_dt"], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[1]["value"], r_params[1]["type"]),
+            (parameters["channels"][0], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[2]["value"], r_params[2]["type"]),
+            (parameters["channels"][1], "VARCHAR"),
+        )
+
+        self.assertEqual(
+            (r_params[3]["value"], r_params[3]["type"]),
+            (parameters["added_gt"], "INTEGER"),
+        )
+
+    def test_apply_dynamic_parameters_no_params(self):
+        self.assertEqual(
+            apply_dynamic_parameters('SELECT 100 AS "100%"', None),
+            ('SELECT 100 AS "100%"', None),
+        )
+
+    def test_apply_dynamic_parameters_no_match_error(self):
+
+        with self.assertRaises(OperationalError) as cm:
+            apply_dynamic_parameters("SELECT %(name)s", {"age": 15})
+
+        self.assertEqual("Parameters and placeholders do not match", str(cm.exception))
+
+    def test_dynamic_parameter(self):
+        self.assertEqual(dynamic_parameter("str"), {"value": "str", "type": "VARCHAR"})
+
+        self.assertEqual(dynamic_parameter(5), {"value": 5, "type": "INTEGER"})
+
+        self.assertEqual(dynamic_parameter(5.5), {"value": 5.5, "type": "FLOAT"})
+
+        self.assertEqual(dynamic_parameter(True), {"value": True, "type": "BOOLEAN"})
+
+    def test_dynamic_placeholder(self):
+        self.assertEqual(dynamic_placeholder(("a", "b")), "?, ?")
+
+        self.assertEqual(dynamic_placeholder(["a", "b"]), "?, ?")
+
+        self.assertEqual(dynamic_placeholder("a"), "?")
 
 
 if __name__ == "__main__":

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -155,7 +155,7 @@ class CursorTestSuite(unittest.TestCase):
         )
 
     @patch("requests.post")
-    def test_execute_with_dynamic_parameter(self, requests_post_mock):
+    def test_execute_with_dynamic_parameters(self, requests_post_mock):
         response = Response()
         response.status_code = 200
         response.raw = BytesIO(b"[]")


### PR DESCRIPTION
This PR adds support for Druids SQL Dynamic Parameters.

- It's backward compatiable for the existing DB API and is a non breaking change and requires opt in
- To opt into using Dynamic Parameters `dynamic_parameters=True` can be set on the `db.api.connect` method. It's set to `False` by default
- It ensures correct ordering in the`context.parameters` JSON payload, regardless of the Dict parameters insertion order ensuring support for Python Verisons `< 3.7`
- Fixes a breaking change introduced in #243 for SQLAlchemy, see more below on this
- Produced queries/requests been tested against Druid 0.18 and above.
- Documented with a working example, inspired from the Druid Tutorial Documentation

**SQLAlchemy breaking change fix**
Exception was being raised when using the DB API independantly of SQLAlchemy, it was attempting to import `CompileError` but this is an optional dependency as defined in `extras_require`. This was introduced in the enhancement #243 - the fix facilitates backwards compatibility but preserves the new enhancement.