### PR TITLE
Use named parameters with Cursor and Connection objects

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -37,17 +37,17 @@ def connect(
     context = context or {}
 
     return Connection(
-        host,
-        port,
-        path,
-        scheme,
-        user,
-        password,
-        context,
-        header,
-        ssl_verify_cert,
-        ssl_client_cert,
-        proxies,
+        host=host,
+        port=port,
+        path=path,
+        scheme=scheme,
+        user=user,
+        password=password,
+        context=context,
+        header=header,
+        ssl_verify_cert=ssl_verify_cert,
+        ssl_client_cert=ssl_client_cert,
+        proxies=proxies,
     )
 
 
@@ -167,14 +167,14 @@ class Connection(object):
         """Return a new Cursor Object using the connection."""
 
         cursor = Cursor(
-            self.url,
-            self.user,
-            self.password,
-            self.context,
-            self.header,
-            self.ssl_verify_cert,
-            self.ssl_client_cert,
-            self.proxies,
+            url=self.url,
+            user=self.user,
+            password=self.password,
+            context=self.context,
+            header=self.header,
+            ssl_verify_cert=self.ssl_verify_cert,
+            proxies=self.proxies,
+            ssl_client_cert=self.ssl_client_cert,
         )
 
         self.cursors.append(cursor)


### PR DESCRIPTION
Closes: https://github.com/druid-io/pydruid/issues/232

Rather than rely on correct parameter ordering, this change switches to using named parameters to avoid out of order parameters.

This resulted in having to do this hack to get client certificate authentication working with Druid and Superset

## hack (bad)
```json
"engine_params": {
    "connect_args": {
      "proxies": "/path/to/my.cert"
    }
}
```

## what it should be (good)

