### PR TITLE
Fix traling whitespace in exception message

### DIFF
--- a/pydruid/async_client.py
+++ b/pydruid/async_client.py
@@ -127,7 +127,7 @@ class AsyncPyDruid(BaseDruidClient):
             else:
                 err = err.get("error", None)
         raise IOError(
-            "{0} \n Druid Error: {1} \n Query is: {2}".format(
+            "{0}\n Druid Error: {1}\n Query is: {2}".format(
                 e, err, json.dumps(query.query_dict, indent=4)
             )
         )

--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -564,7 +564,7 @@ class PyDruid(BaseDruidClient):
                     pass
 
             raise IOError(
-                "{0} \n Druid Error: {1} \n Query is: {2}".format(
+                "{0}\n Druid Error: {1}\n Query is: {2}".format(
                     e,
                     err,
                     json.dumps(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,8 +89,8 @@ class TestPyDruid:
             str(e.value)
             == textwrap.dedent(
                 """
-            HTTP Error 500: Internal Server Error 
-             Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
+            HTTP Error 500: Internal Server Error
+             Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded
              Query is: {
                 "aggregations": [
                     {


### PR DESCRIPTION
The `trailing-whitespace` hook from the `pre-commit-hooks` that's recommended when [contributing](https://github.com/druid-io/pydruid/#contributing) automatically removes the trailing whitespace from the test, making it fail since the expected string doesn't match the actual exception message. 