### PR TITLE
enable support for offset to scan query

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -440,7 +440,7 @@ class QueryBuilder(object):
         query_type = 'scan'
         valid_parts = [
             'datasource', 'granularity', 'filter', 'dimensions', 'metrics',
-            'intervals', 'limit',
+            'intervals', 'limit', 'offset'
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)


### PR DESCRIPTION
Hi @mistercrunch,

Adding support for offset to Scan query as Select query is remove from Druid which support pagination.
Reference :- https://druid.apache.org/docs/latest/querying/scan-query.html