### PR TITLE
enable support for offset to scan query

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -516,6 +516,7 @@ class QueryBuilder(object):
             "intervals",
             "limit",
             "order",
+            "offset"
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)


### PR DESCRIPTION
Hi @mistercrunch,

Adding support for offset to Scan query as Select query is remove from Druid which support pagination.
Reference :- https://druid.apache.org/docs/latest/querying/scan-query.html