### PR TITLE
SQLAlchemy 1.4 compat

### DIFF
--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -1,4 +1,4 @@
-from sqlalchemy import types
+from sqlalchemy import text, types
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
 
@@ -122,7 +122,7 @@ class DruidDialect(default.DefaultDialect):
         # is also the default schema, so Druid datasources can be referenced as
         # either druid.dataSourceName or simply dataSourceName.
         result = connection.execute(
-            "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA"
+            text("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA")
         )
 
         return [
@@ -138,7 +138,7 @@ class DruidDialect(default.DefaultDialect):
             table_name=table_name
         )
 
-        result = connection.execute(query)
+        result = connection.execute(text(query))
         return result.fetchone().exists_
 
     def get_table_names(self, connection, schema=None, **kwargs):
@@ -148,7 +148,7 @@ class DruidDialect(default.DefaultDialect):
                 query=query, schema=schema
             )
 
-        result = connection.execute(query)
+        result = connection.execute(text(query))
         return [row.TABLE_NAME for row in result]
 
     def get_view_names(self, connection, schema=None, **kwargs):
@@ -173,7 +173,7 @@ class DruidDialect(default.DefaultDialect):
                 query=query, schema=schema
             )
 
-        result = connection.execute(query)
+        result = connection.execute(text(query))
 
         return [
             {


### PR DESCRIPTION
SQLAlchemy 1.4 now requires executed strings to be wrapped in `text()`.

I tested the branch with SQLAlchemy 1.4.5 and it works as expected. Before, it would raise an error:

```
sqlalchemy.exc.ObjectNotExecutableError: Not an executable object
```