### PR TITLE
fix: do_ping to be executed on raw_connection

### DIFF
--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -122,8 +122,8 @@ class DruidDialect(default.DefaultDialect):
         Return if the database can be reached.
         """
         try:
-            dbapi_connection.execute(text('SELECT 1'))
-        except Exception as ex:
+            dbapi_connection.execute("SELECT 1")
+        except Exception:
             return False
 
         return True

--- a/tests/db/test_dialect.py
+++ b/tests/db/test_dialect.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from pydruid.db.sqlalchemy import DruidDialect
+
+
+class DruidDialectTestSuite(unittest.TestCase):
+    dialect = DruidDialect()
+
+    @patch("pydruid.db.api.Connection")
+    def test_do_ping_success(self, connection_mock):
+        connection_mock.execute.return_value = [1]
+
+        result = self.dialect.do_ping(connection_mock)
+
+        # asserts the ping executes with a raw string
+        connection_mock.execute.assert_called_once_with("SELECT 1")
+        self.assertTrue(result)
+
+    @patch("pydruid.db.api.Connection")
+    def test_do_ping_with_exception(self, connection_mock):
+        connection_mock.execute.side_effect = Exception("Something's wrong :(")
+
+        result = self.dialect.do_ping(connection_mock)
+
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adding a new Druid database on Superset fails, because the pings are unsuccessful. It turns out that pydruid's implementation of `do_ping` is at fault here and not Superset.

Other dialects expect `do_ping` to be called on a raw connection (`engine.raw_connection()` instead of `engine.connect()` or similar). In fact, we can see that sqlalchemy's pool implementation executes pings on the raw connection, which currently fails for our Druid dialect. When executing pydruid's `do_ping` on a raw connection we fail because the result of `text(...)` is not properly parsed to a `str`.

A simple script shows the problem; I'm setting `pool_pre_ping` to `True` here so we get an instant failure, the engine cannot connect because the ping fails.
```
from sqlalchemy import create_engine

engine = create_engine('druid://druid-router.dca.tumblr.net:8082/druid/v2/sql', pool_pre_ping=True)
conn = engine.connect()
# => exception
```