### PR TITLE
Include URL query params in create_connect_args()

### DIFF
--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -106,6 +106,7 @@ class DruidDialect(default.DefaultDialect):
 
     def create_connect_args(self, url):
         kwargs = {
+            **url.query,
             "host": url.host,
             "port": url.port or 8082,
             "user": url.username or None,
@@ -113,8 +114,7 @@ class DruidDialect(default.DefaultDialect):
             "path": url.database,
             "scheme": self.scheme,
             "context": self.context,
-            "header": url.query.get("header") == "true",
-            **url.query
+            "header": url.query.get("header") == "true"
         }
         return ([], kwargs)
 

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -114,6 +114,7 @@ class DruidDialect(default.DefaultDialect):
             "scheme": self.scheme,
             "context": self.context,
             "header": url.query.get("header") == "true",
+            **url.query
         }
         return ([], kwargs)
 

--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -114,7 +114,7 @@ class DruidDialect(default.DefaultDialect):
             "path": url.database,
             "scheme": self.scheme,
             "context": self.context,
-            "header": url.query.get("header") == "true"
+            "header": url.query.get("header") == "true",
         }
         return ([], kwargs)
 


### PR DESCRIPTION
This PR adds support for Druid connection options (`ssl_verify_cert`, etc.) using a SqlAlchemy connection URL