### PR TITLE
Correct order of parameters for Cursor's init

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -204,8 +204,8 @@ class Cursor(object):
         context=None,
         header=False,
         ssl_verify_cert=True,
-        proxies=None,
         ssl_client_cert=None,
+        proxies=None
     ):
         self.url = url
         self.context = context or {}

--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -205,7 +205,7 @@ class Cursor(object):
         header=False,
         ssl_verify_cert=True,
         ssl_client_cert=None,
-        proxies=None
+        proxies=None,
     ):
         self.url = url
         self.context = context or {}


### PR DESCRIPTION
Fix for issue https://github.com/druid-io/pydruid/issues/300

Order of parameters passed has `ssl_client_cert ` followed by `proxies`
https://github.com/druid-io/pydruid/blob/master/pydruid/db/api.py#L176-L177

