### PR TITLE
Explicit intervals and datasource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:
     -   id: black
@@ -21,7 +21,13 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.8.2
     hooks:
     -   id: flake8
+        exclude:
+            docs
+            env
+            tests
+            .eggs
+            build

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -247,7 +247,7 @@ class QueryBuilder(object):
                 "dict or list of strings"
             )
         if isinstance(datasource, str):
-            return datasource
+            return {"type": "table", "name": datasource}
         else:
             return {"type": "union", "dataSources": datasource}
 
@@ -310,6 +310,8 @@ class QueryBuilder(object):
                 query_dict[key] = build_dimension(val)
             elif key == "dimensions":
                 query_dict[key] = [build_dimension(v) for v in val]
+            elif key == "intervals":
+                query_dict[key] = {"type": "intervals", key: val}
             else:
                 query_dict[key] = val
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,8 +89,8 @@ class TestPyDruid:
             str(e.value)
             == textwrap.dedent(
                 """
-            HTTP Error 500: Internal Server Error 
-             Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded 
+            HTTP Error 500: Internal Server Error
+             Druid Error: javax.servlet.ServletException: java.lang.OutOfMemoryError: GC overhead limit exceeded
              Query is: {
                 "aggregations": [
                     {
@@ -102,7 +102,10 @@ class TestPyDruid:
                 "context": {
                     "timeout": 1000
                 },
-                "dataSource": "testdatasource",
+                "dataSource": {
+                    "name": "testdatasource",
+                    "type": "table"
+                },
                 "dimension": "user_name",
                 "filter": {
                     "dimension": "user_lang",
@@ -110,7 +113,10 @@ class TestPyDruid:
                     "value": "en"
                 },
                 "granularity": "all",
-                "intervals": "2015-12-29/pt1h",
+                "intervals": {
+                    "intervals": "2015-12-29/pt1h",
+                    "type": "intervals"
+                },
                 "metric": "count",
                 "queryType": "topN",
                 "threshold": 1

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,7 +16,6 @@
 #
 
 import csv
-import os
 
 import pandas
 import pytest
@@ -62,7 +61,7 @@ class TestQueryBuilder:
         # given
         expected_query_dict = {
             "queryType": None,
-            "dataSource": "things",
+            "dataSource": {"name": "things", "type": "table"},
             "aggregations": [{"fieldName": "thing", "name": "count", "type": "count"}],
             "postAggregations": [
                 {
@@ -106,7 +105,7 @@ class TestQueryBuilder:
         # given
         expected_query_dict = {
             "queryType": None,
-            "dataSource": "things",
+            "dataSource": {"name": "things", "type": "table"},
             "aggregations": [{"fieldName": "thing", "name": "count", "type": "count"}],
             "filter": {"dimension": "one", "type": "selector", "value": 1},
             "having": {"aggregation": "sum", "type": "greaterThan", "value": 1},
@@ -153,7 +152,10 @@ class TestQueryBuilder:
 
     def test_union_datasource(self):
         # Given
-        expected_query_dict = {"queryType": None, "dataSource": "things"}
+        expected_query_dict = {
+            "queryType": None,
+            "dataSource": {"name": "things", "type": "table"},
+        }
         builder = QueryBuilder()
         # when
         builder_dict = {"datasource": "things"}
@@ -187,7 +189,7 @@ class TestQueryBuilder:
         expected_query_dict = {
             "query": {
                 "queryType": "groupBy",
-                "dataSource": "things",
+                "dataSource": {"name": "things", "type": "table"},
                 "aggregations": [
                     {"fieldName": "thing", "name": "count", "type": "count"}
                 ],


### PR DESCRIPTION
To maintain parity between druid clients such as go-druid and pydruid we need to express the intervals and datasource explicitly or in the fully expanded native query form. 
