### PR TITLE
fix(SQLAlchemy): queries w/o parameters

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -429,7 +429,7 @@ def rows_from_chunks(chunks):
 
 def apply_parameters(operation, parameters):
     if not parameters:
-        return operation
+        return operation % ()
 
     escaped_parameters = {key: escape(value) for key, value in parameters.items()}
     return operation % escaped_parameters

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -121,11 +121,11 @@ class CursorTestSuite(unittest.TestCase):
 
     def test_apply_parameters(self):
         self.assertEqual(
-            apply_parameters('SELECT 100 AS "100%"', None), 'SELECT 100 AS "100%"'
+            apply_parameters('SELECT 100 AS "100%%"', None), 'SELECT 100 AS "100%"'
         )
 
         self.assertEqual(
-            apply_parameters('SELECT 100 AS "100%"', {}), 'SELECT 100 AS "100%"'
+            apply_parameters('SELECT 100 AS "100%%"', {}), 'SELECT 100 AS "100%"'
         )
 
         self.assertEqual(
@@ -145,6 +145,11 @@ class CursorTestSuite(unittest.TestCase):
 
         self.assertEqual(
             apply_parameters("SELECT %(key)s", {"key": False}), "SELECT FALSE"
+        )
+
+        self.assertEqual(
+            apply_parameters("SELECT * FROM t WHERE name LIKE '%%a'", None),
+            "SELECT * FROM t WHERE name LIKE '%a'",
         )
 
 


### PR DESCRIPTION
Because the DB driver is using `pyformat` for `paramstyle,` queries compiled by SQLAlchemy will double any percents signs in the text:

```sql
SELECT * FROM t WHERE name LIKE '%%a' AND job = '%s'
```

So that when running the query via:

```python
cursor.execute(sql, ("designer",))
```

The parameters are applied to the SQL via:

```python
sql = "SELECT * FROM t WHERE name LIKE '%%a' AND job = '%s'"
parameters = ("designer",)
final_query = sql % parameters
```

Becoming:

```sql
SELECT * FROM t WHERE name LIKE '%a' AND job = 'designer'
```

The problem is that if no parameters are present the function `apply_parameters` will return the SQL immediately, with any double percents remaining in the final query. This produces valid queries (`LIKE '%%a'` is valid), but for some reason the performance of these queries is much worse compared to the correct query (`LIKE '%a'`).

This PR fixes the problem by always removing duplicate percents, even when no parameters are passed.