### PR TITLE
fix: revert #317

### DIFF
--- a/pydruid/db/api.py
+++ b/pydruid/db/api.py
@@ -429,7 +429,7 @@ def rows_from_chunks(chunks):
 
 def apply_parameters(operation, parameters):
     if not parameters:
-        return operation % ()
+        return operation
 
     escaped_parameters = {key: escape(value) for key, value in parameters.items()}
     return operation % escaped_parameters

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -121,11 +121,11 @@ class CursorTestSuite(unittest.TestCase):
 
     def test_apply_parameters(self):
         self.assertEqual(
-            apply_parameters('SELECT 100 AS "100%%"', None), 'SELECT 100 AS "100%"'
+            apply_parameters('SELECT 100 AS "100%"', None), 'SELECT 100 AS "100%"'
         )
 
         self.assertEqual(
-            apply_parameters('SELECT 100 AS "100%%"', {}), 'SELECT 100 AS "100%"'
+            apply_parameters('SELECT 100 AS "100%"', {}), 'SELECT 100 AS "100%"'
         )
 
         self.assertEqual(
@@ -145,11 +145,6 @@ class CursorTestSuite(unittest.TestCase):
 
         self.assertEqual(
             apply_parameters("SELECT %(key)s", {"key": False}), "SELECT FALSE"
-        )
-
-        self.assertEqual(
-            apply_parameters("SELECT * FROM t WHERE name LIKE '%%a'", None),
-            "SELECT * FROM t WHERE name LIKE '%a'",
         )
 
 


### PR DESCRIPTION
I think #317 was a mistake. The behavior for `pyformat` when no parameters are passed is undefined, but it seems that Presto, Hive, MySQL, and other databases will take unescaped percent symbols when no parameters are passed. Since the behavior is undefined, I'm reverting this to align with other DB API drivers.