### PR TITLE
Add subtotalsSpec as a valid part for group by

### DIFF
--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -394,6 +394,7 @@ class QueryBuilder(object):
             "dimensions",
             "limit_spec",
             "virtualColumns",
+            "subtotalsSpec"
         ]
         self.validate_query(query_type, valid_parts, args)
         return self.build_query(query_type, args)


### PR DESCRIPTION
Adding `subtotalsSpec` as a `valid_part` for groupBy. This is based on this section of a [doc](https://druid.apache.org/docs/latest/querying/groupbyquery#more-on-subtotalsspec). 

It should allow users to manually pass `subtotalsSpec`

Let me know if anything should be changed or added!