### PR TITLE
passing additional HTTP headers to druid client

### DIFF
--- a/pydruid/client.py
+++ b/pydruid/client.py
@@ -25,10 +25,11 @@ HTML_ERROR = re.compile("<pre>\\s*(.*?)\\s*</pre>", re.IGNORECASE)
 
 
 class BaseDruidClient(object):
-    def __init__(self, url, endpoint):
+    def __init__(self, url, endpoint, http_headers=None):
         self.url = url
         self.endpoint = endpoint
         self.query_builder = QueryBuilder()
+        self.http_headers = http_headers or {}
         self.username = None
         self.password = None
         self.proxies = None
@@ -54,6 +55,8 @@ class BaseDruidClient(object):
             authstring = "{}:{}".format(self.username, self.password)
             b64string = b64encode(authstring.encode()).decode()
             headers["Authorization"] = "Basic {}".format(b64string)
+
+        headers.update(self.http_headers)
 
         return headers, querystr, url
 
@@ -544,8 +547,8 @@ class PyDruid(BaseDruidClient):
                 1      6  2013-10-04T00:00:00.000Z         user_2
     """
 
-    def __init__(self, url, endpoint, cafile=None):
-        super(PyDruid, self).__init__(url, endpoint)
+    def __init__(self, url, endpoint, cafile=None, http_headers=None):
+        super(PyDruid, self).__init__(url, endpoint, http_headers=http_headers)
         self.cafile = cafile
 
     def _post(self, query):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,8 +12,8 @@ from pydruid.utils.aggregators import doublesum
 from pydruid.utils.filters import Dimension
 
 
-def create_client():
-    return PyDruid("http://localhost:8083", "druid/v2/")
+def create_client(http_headers=None):
+    return PyDruid("http://localhost:8083", "druid/v2/", http_headers=http_headers)
 
 
 def create_blank_query():
@@ -189,10 +189,15 @@ class TestPyDruid:
         with pytest.raises(TypeError):
             client.export_tsv(None)
 
-    @patch("pydruid.client.urllib.request.urlopen")
-    def test_client_auth_creds(self, mock_urlopen):
+    def test_client_auth_creds(self):
         client = create_client()
         query = create_blank_query()
         client.set_basic_auth_credentials("myUsername", "myPassword")
         headers, _, _ = client._prepare_url_headers_and_body(query)
         assert headers["Authorization"] == "Basic bXlVc2VybmFtZTpteVBhc3N3b3Jk"
+
+    def test_client_custom_headers(self):
+        client = create_client(http_headers = {"custom-header": "test"})
+        query = create_blank_query()
+        headers, _, _ = client._prepare_url_headers_and_body(query)
+        assert headers["custom-header"] == "test"


### PR DESCRIPTION
Partially resolves: https://github.com/druid-io/pydruid/issues/154

This PR allows setting custom headers on pydruid's HTTP requests.

This can be required in some situations - in our case we are trying to route requests to druid through an HTTP proxy which directs traffic based on `host` headers, but can't do this using an out-of-the-box pydruid client.

This potentially exposes some weirdness as users can overwrite the "reserved" headers (`Content-Type`, `Authorization`), but I don't think it should be the library's job to prevent that sort of thing.