### PR TITLE
Fixes for failing tests

### DIFF
--- a/pydruid/db/sqlalchemy.py
+++ b/pydruid/db/sqlalchemy.py
@@ -123,8 +123,8 @@ class DruidDialect(default.DefaultDialect):
         Return if the database can be reached.
         """
         try:
-            dbapi_connection.execute(text("SELECT 1"))
-        except Exception as ex:
+            dbapi_connection.execute("SELECT 1")
+        except Exception:
             return False
 
         return True

--- a/pydruid/query.py
+++ b/pydruid/query.py
@@ -246,6 +246,8 @@ class QueryBuilder(object):
                 "Datasource definition not valid. Must be string or "
                 "dict or list of strings"
             )
+        if isinstance(datasource, list):
+            return {"type": "union", "dataSources": datasource}
         return datasource
 
     @staticmethod

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -355,7 +355,7 @@ class CursorTestSuite(unittest.TestCase):
             ANY,
             stream=True,
             headers={"Content-Type": "application/json"},
-            json={"query": "SELECT * FROM table", "context": {}, "header": False},
+            json={"query": "SELECT * FROM table", "context": {}, "header": True},
             auth=ANY,
             verify=True,
             cert="path/to/cert",


### PR DESCRIPTION
A few of these tests are failing on master currently:

```
> pytest
...
================================================================= short test summary info ==================================================================
FAILED tests/test_query.py::TestQueryBuilder::test_union_datasource - AssertionError: assert {'dataSource'...ryType': None} == {'dataSource'...ryType': N...
FAILED tests/db/test_cursor.py::CursorTestSuite::test_ssl_client_cert_authentication_with_patch_imported - AssertionError: expected call not found.
FAILED tests/db/test_druid_dialect.py::DruidDialectTestSuite::test_do_ping_success - AssertionError: expected call not found.
============================================================== 3 failed, 124 passed in 0.52s ===============================================================
```

I have made what I think is the most reasonable correction in each case, either reverting breaking code changes or fixing up tests and left comments on this PR explaining my rationale. Let me know what you think!