### PR TITLE
finalizingFieldAccess support to Postaggregation

### DIFF
--- a/pydruid/utils/postaggregator.py
+++ b/pydruid/utils/postaggregator.py
@@ -93,6 +93,12 @@ class Field(Postaggregator):
         self.post_aggregator = {"type": "fieldAccess", "fieldName": name}
 
 
+class FinalizingField(Postaggregator):
+    def __init__(self, name):
+        Postaggregator.__init__(self, None, None, name)
+        self.post_aggregator = {"type": "finalizingFieldAccess", "fieldName": name}
+
+
 class Const(Postaggregator):
     def __init__(self, value, output_name=None):
 


### PR DESCRIPTION
Any operation on aggregations that requires access to the final result (hyperunique, cardinality, datasketches, ...) requires the use of finalizingFieldAccess in post-aggregation.

This PR fix this missing field in current pydruid implementation.

In this way, I can create now post-aggregations like:
```python
from pydruid.utils.postaggregator import Field, Const, FinalizingField
...
post_aggregation = {
                **post_aggregation,
                metric_name: (
                    Const(100) * FinalizingField(f"{metric_name}-{left_metric.value}") /
                    Field(f"{metric_name}-{right_metric.value}")
                )
            }
```